### PR TITLE
Change the invoice state only after Bitcoin has been sent from wallet

### DIFF
--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Controllers/PayrollInvoiceController.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Controllers/PayrollInvoiceController.cs
@@ -84,17 +84,6 @@ public class PayrollInvoiceController : Controller
             .Where(p => p.User.StoreId == storeId && !p.IsArchived)
             .OrderByDescending(data => data.CreatedAt).ToListAsync();
 
-        if (!string.IsNullOrEmpty(payrollInvoiceId))
-        {
-            List<string> payrollInvoiceIds = payrollInvoiceId.Split(",", StringSplitOptions.RemoveEmptyEntries).ToList();
-            foreach (var invoiceId in payrollInvoiceIds)
-            {
-                if (payrollInvoices.Find(c => c.Id == invoiceId) is PayrollInvoice invoice)
-                    invoice.State = PayrollInvoiceState.AwaitingPayment;
-            }
-            await ctx.SaveChangesAsync();
-        }
-
         var pendingPayrollInvoices = payrollInvoices.Where(c => c.State == PayrollInvoiceState.Pending).ToList();
         if (pendingPayrollInvoices.Any())
         {

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Controllers/PayrollUserController.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Controllers/PayrollUserController.cs
@@ -245,33 +245,40 @@ public class PayrollUserController : Controller
         using var ms = new MemoryStream();
         using var zip = new ZipArchive(ms, ZipArchiveMode.Create, true);
 
-        if (payrollInvoices.Count > 0)
+        if (!payrollInvoices.Any())
         {
-            var csvData = new StringBuilder();
-            csvData.AppendLine("Name,Destination,Amount,Currency,Description,Status");
-            foreach (var invoice in payrollInvoices)
+            TempData.SetStatusMessageModel(new StatusMessageModel()
             {
-                csvData.AppendLine(
-                    $"{invoice.User.Name},{invoice.Destination},{invoice.Amount},{invoice.Currency},{invoice.Description},{invoice.State}");
+                Message = $"No invoice found for this user ({user.Name})",
+                Severity = StatusMessageModel.StatusSeverity.Error
+            });
+            return RedirectToAction(nameof(List), new { storeId = CurrentStore.Id });
+        }
 
-                var fileUrl =
-                    await _fileService.GetFileUrl(HttpContext.Request.GetAbsoluteRootUri(), invoice.InvoiceFilename);
-                var fileBytes = await _httpClient.DownloadFileAsByteArray(fileUrl);
-                string filename = Path.GetFileName(fileUrl);
-                string extension = Path.GetExtension(filename);
-                var entry = zip.CreateEntry($"{filename}{extension}");
-                using (var entryStream = entry.Open())
-                {
-                    await entryStream.WriteAsync(fileBytes, 0, fileBytes.Length);
-                }
-            }
+        var csvData = new StringBuilder();
+        csvData.AppendLine("Name,Destination,Amount,Currency,Description,Status");
+        foreach (var invoice in payrollInvoices)
+        {
+            csvData.AppendLine(
+                $"{invoice.User.Name},{invoice.Destination},{invoice.Amount},{invoice.Currency},{invoice.Description},{invoice.State}");
 
-            var csv = zip.CreateEntry($"Invoices-{DateTime.Now:yyyy_MM_dd-HH_mm_ss}.csv");
-            await using (var entryStream = csv.Open())
+            var fileUrl =
+                await _fileService.GetFileUrl(HttpContext.Request.GetAbsoluteRootUri(), invoice.InvoiceFilename);
+            var fileBytes = await _httpClient.DownloadFileAsByteArray(fileUrl);
+            string filename = Path.GetFileName(fileUrl);
+            string extension = Path.GetExtension(filename);
+            var entry = zip.CreateEntry($"{filename}{extension}");
+            using (var entryStream = entry.Open())
             {
-                var csvBytes = Encoding.UTF8.GetBytes(csvData.ToString());
-                await entryStream.WriteAsync(csvBytes);
+                await entryStream.WriteAsync(fileBytes, 0, fileBytes.Length);
             }
+        }
+
+        var csv = zip.CreateEntry($"Invoices-{DateTime.Now:yyyy_MM_dd-HH_mm_ss}.csv");
+        await using (var entryStream = csv.Open())
+        {
+            var csvBytes = Encoding.UTF8.GetBytes(csvData.ToString());
+            await entryStream.WriteAsync(csvBytes);
         }
 
         return File(ms.ToArray(), "application/zip", zipName);

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Data/Models/PayrollInvoice.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Data/Models/PayrollInvoice.cs
@@ -39,5 +39,6 @@ public enum PayrollInvoiceState
     AwaitingPayment,
     InProgress, // waiting for confirmation on blockchain (or for lightning it can be stuck HTLC
     Completed,
-    Cancelled
+    Cancelled,
+    Pending
 }

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Views/PayrollInvoice/List.cshtml
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Views/PayrollInvoice/List.cshtml
@@ -151,7 +151,7 @@
                             </td>
                             <td class="text-end">
                                 <a href="/Storage/@pp.InvoiceUrl">View Invoice</a>
-                                @if (pp.State == PayrollInvoiceState.AwaitingApproval)
+                                @if (pp.State == PayrollInvoiceState.AwaitingApproval || pp.State == PayrollInvoiceState.Pending)
                                 {
                                     <span>-</span>
                                     <a asp-controller="PayrollInvoice"
@@ -178,22 +178,23 @@
                 pp.setAttribute("title", template.innerHTML);
             }
 
-            function allSelectedInState(state) {
+            function allSelectedInState(allowedStates) {
                 var allCheckedItems = document.querySelectorAll('input[type="checkbox"].mass-action-select:checked');
                 if (allCheckedItems.length === 0) return false;
                 return Array.from(allCheckedItems).every(function (checkbox) {
                     var row = checkbox.closest('tr');
                     var stateCell = row.querySelector('td:nth-child(7)');
-                    return stateCell.textContent.trim() === state;
+                    return allowedStates.includes(stateCell.textContent.trim());
                 });
             }
 
-            function selectedItemInState(state) {
+            function selectedItemInState(allowedStates) {
                 var allCheckedItems = document.querySelectorAll('input[type="checkbox"]:checked');
                 return Array.from(allCheckedItems).every(function (checkbox) {
                     var row = checkbox.closest('tr');
                     var stateCell = row.querySelector('td:nth-child(7)');
-                    return stateCell.textContent.trim() === state;
+                    var currentState = stateCell.textContent.trim();
+                    return allowedStates.includes(stateCell.textContent.trim());
                 });
             }
 
@@ -202,11 +203,11 @@
                 var payInvoicesButton = document.getElementById('payinvoices');
                 var selectAllCheckbox = document.querySelector('.mass-action-select-all');
                 if (selectAllCheckbox.checked) {
-                    payInvoicesButton.style.display = allSelectedInState('AwaitingApproval') ? 'inline-block' : 'none';
-                    markPaidButton.style.display = allSelectedInState('AwaitingApproval') || allSelectedInState('AwaitingPayment') || allSelectedInState('InProgress') ? 'inline-block' : 'none';
+                    payInvoicesButton.style.display = allSelectedInState(['AwaitingApproval', 'Pending']) ? 'inline-block' : 'none';
+                    markPaidButton.style.display = allSelectedInState(['AwaitingApproval', 'Pending']) || allSelectedInState(['AwaitingPayment']) || allSelectedInState(['InProgress']) ? 'inline-block' : 'none';
                 } else {
-                    payInvoicesButton.style.display = selectedItemInState('AwaitingApproval') ? 'inline-block' : 'none';
-                    markPaidButton.style.display = selectedItemInState('AwaitingApproval') || selectedItemInState('AwaitingPayment') || selectedItemInState('InProgress') ? 'inline-block' : 'none';
+                    payInvoicesButton.style.display = selectedItemInState(['AwaitingApproval', 'Pending']) ? 'inline-block' : 'none';
+                    markPaidButton.style.display = selectedItemInState(['AwaitingApproval', 'Pending']) || selectedItemInState(['AwaitingPayment']) || selectedItemInState(['InProgress']) ? 'inline-block' : 'none';
                 }
             }
             document.addEventListener('change', function (event) {


### PR DESCRIPTION
Resolves #28  

So I tried out an implementation for the issue. 

the returnUrl parameter on the UIWallets.WalletSend is now populated with invoiceIds. Then, when Bitcoin is sent from this page and the user is redirected back to PayrollUserController.List, then the status is updated.

![image](https://github.com/rockstardev/BTCPayServerPlugins.RockstarDev/assets/47084273/d9933d8d-9d69-4a36-b002-7dd0c5486186)


But the only concern here, is that when the modal close icon is clicked, it would redirect to the return url which would include the invoice Id and then by default update the status