### PR TITLE
Paid date to payroll csv

### DIFF
--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Controllers/PayrollInvoiceController.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Controllers/PayrollInvoiceController.cs
@@ -128,7 +128,7 @@ public class PayrollInvoiceController(
                 invoices.ForEach(c =>
                 {
                     c.State = PayrollInvoiceState.Completed;
-                    c.PaidAt = DateTime.Now;
+                    c.PaidAt = DateTimeOffset.UtcNow;
                 });
                 ctx.SaveChanges();
                 TempData.SetStatusMessageModel(new StatusMessageModel()
@@ -455,7 +455,7 @@ public class PayrollInvoiceController(
         var fileName = $"PayrollInvoices-{DateTime.Now:yyyy_MM_dd-HH_mm_ss}.csv";
 
         var csvData = new StringBuilder();
-        csvData.AppendLine("Created Date,Transaction Date,Name,InvoiceId,Address,Currency,Amount,Balance,BTCUSD Rate, BTCJPY Rate,Balance,TransactionId,PaidInWallet");
+        csvData.AppendLine("Created Date,Transaction Date,Name,InvoiceId,Address,Currency,Amount,BTCUSD Rate, BTCJPY Rate,TransactionId,PaidInWallet");
         string emptyStr = string.Empty;
         decimal usdRate = 0;
         foreach (var invoice in invoices)
@@ -463,8 +463,8 @@ public class PayrollInvoiceController(
             if (invoice.BtcPaid == null)
             {
                 csvData.AppendLine($"{invoice.CreatedAt:MM/dd/yy HH:mm},{invoice.PaidAt?.ToString("MM/dd/yy HH:mm") ?? emptyStr},{invoice.User.Name},{invoice.Id}," +
-                                   $"{invoice.Destination},{invoice.Currency},{invoice.Amount},{usdRate},{emptyStr}" +
-                                   $",{usdRate},{emptyStr},{emptyStr},false");
+                                   $"{invoice.Destination},{invoice.Currency},-{invoice.Amount},{emptyStr},{emptyStr}," +
+                                   $"{emptyStr},false");
             }
             else
             {
@@ -478,9 +478,9 @@ public class PayrollInvoiceController(
                     usdRate = Math.Abs(usdRate);
                 }
 
-                csvData.AppendLine($"{invoice.CreatedAt:MM/dd/yy HH:mm},{txn?.Timestamp.ToString("MM/dd/yy HH:mm")},{invoice.User.Name},{emptyStr}" +
-                                   $",{invoice.Destination},{invoice.Currency},-{invoice.Amount},{usdRate},{emptyStr}" +
-                                   $",-{invoice.BtcPaid},{emptyStr},{invoice.TxnId},true");
+                csvData.AppendLine($"{invoice.CreatedAt:MM/dd/yy HH:mm},{invoice.PaidAt.Value.ToString("MM/dd/yy HH:mm")},{invoice.User.Name},{invoice.Id}" +
+                                   $",{invoice.Destination},{invoice.Currency},-{invoice.Amount},{usdRate},{emptyStr}," +
+                                   $"{invoice.TxnId},true");
             }
         }
         

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Controllers/PayrollInvoiceController.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Controllers/PayrollInvoiceController.cs
@@ -130,7 +130,9 @@ public class PayrollInvoiceController(
                     c.State = PayrollInvoiceState.Completed;
                     c.PaidAt = DateTimeOffset.UtcNow;
                 });
-                ctx.SaveChanges();
+                await ctx.SaveChangesAsync();
+                
+                // Mark Paid doesn't trigger "paid" email sending, it's something we can add in future versions
                 TempData.SetStatusMessageModel(new StatusMessageModel()
                 {
                     Message = $"Invoices successfully marked as paid",
@@ -455,16 +457,17 @@ public class PayrollInvoiceController(
         var fileName = $"PayrollInvoices-{DateTime.Now:yyyy_MM_dd-HH_mm_ss}.csv";
 
         var csvData = new StringBuilder();
-        csvData.AppendLine("Created Date,Transaction Date,Name,InvoiceId,Address,Currency,Amount,BTCUSD Rate, BTCJPY Rate,TransactionId,PaidInWallet");
+        // We preserve this format with duplicate fields because Emperor Nicolas Dorier uses it, maybe in future we add compatibility mode
+        csvData.AppendLine("Created Date,Transaction Date,Name,InvoiceId,Address,Currency,Amount,Balance,BTCUSD Rate,BTCJPY Rate,Balance,TransactionId,PaidInWallet");
         string emptyStr = string.Empty;
         decimal usdRate = 0;
         foreach (var invoice in invoices)
         {
             if (invoice.BtcPaid == null)
             {
-                csvData.AppendLine($"{invoice.CreatedAt:MM/dd/yy HH:mm},{invoice.PaidAt?.ToString("MM/dd/yy HH:mm") ?? emptyStr},{invoice.User.Name},{invoice.Id}," +
-                                   $"{invoice.Destination},{invoice.Currency},-{invoice.Amount},{emptyStr},{emptyStr}," +
-                                   $"{emptyStr},false");
+                csvData.AppendLine($"{invoice.CreatedAt:MM/dd/yy HH:mm},{invoice.PaidAt?.ToString("MM/dd/yy HH:mm") ?? emptyStr},{invoice.User.Name},{invoice.Description}," +
+                                   $"{invoice.Destination},{invoice.Currency},-{invoice.Amount},{usdRate},{emptyStr}" +
+                                   $",{usdRate},{emptyStr},{emptyStr},false");
             }
             else
             {
@@ -478,9 +481,9 @@ public class PayrollInvoiceController(
                     usdRate = Math.Abs(usdRate);
                 }
 
-                csvData.AppendLine($"{invoice.CreatedAt:MM/dd/yy HH:mm},{invoice.PaidAt.Value.ToString("MM/dd/yy HH:mm")},{invoice.User.Name},{invoice.Id}" +
-                                   $",{invoice.Destination},{invoice.Currency},-{invoice.Amount},{usdRate},{emptyStr}," +
-                                   $"{invoice.TxnId},true");
+                csvData.AppendLine($"{invoice.CreatedAt:MM/dd/yy HH:mm},{invoice.PaidAt?.ToString("MM/dd/yy HH:mm" ?? emptyStr)},{invoice.User.Name},{invoice.Description}" +
+                                   $",{invoice.Destination},{invoice.Currency},-{invoice.Amount},{usdRate},{emptyStr}" +
+                                   $",-{invoice.BtcPaid},{emptyStr},{invoice.TxnId},true");
             }
         }
         

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Controllers/PayrollInvoiceController.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Controllers/PayrollInvoiceController.cs
@@ -125,7 +125,11 @@ public class PayrollInvoiceController(
                 return await payInvoices(selectedItems);
 
             case "markpaid":
-                invoices.ForEach(c => c.State = PayrollInvoiceState.Completed);
+                invoices.ForEach(c =>
+                {
+                    c.State = PayrollInvoiceState.Completed;
+                    c.PaidAt = DateTime.Now;
+                });
                 ctx.SaveChanges();
                 TempData.SetStatusMessageModel(new StatusMessageModel()
                 {
@@ -458,7 +462,7 @@ public class PayrollInvoiceController(
         {
             if (invoice.BtcPaid == null)
             {
-                csvData.AppendLine($"{invoice.CreatedAt:MM/dd/yy HH:mm},{emptyStr},{invoice.User.Name},{invoice.Id}," +
+                csvData.AppendLine($"{invoice.CreatedAt:MM/dd/yy HH:mm},{invoice.PaidAt?.ToString("MM/dd/yy HH:mm") ?? emptyStr},{invoice.User.Name},{invoice.Id}," +
                                    $"{invoice.Destination},{invoice.Currency},{invoice.Amount},{usdRate},{emptyStr}" +
                                    $",{usdRate},{emptyStr},{emptyStr},false");
             }

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Views/PayrollInvoice/List.cshtml
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Views/PayrollInvoice/List.cshtml
@@ -57,7 +57,7 @@
 
 @if (Model.PayrollInvoices.Any())
 {
-    <form method="post" asp-action="MassAction">
+    <form method="post" asp-action="MassAction" asp-route-storeId="@storeId">
         <div class="table-responsive">
             <table class="table table-hover mass-action">
                 <thead class="mass-action-head">


### PR DESCRIPTION
Resolves #59 

- Transaction date was existing alongside the invoice creation date. What was missing was when an invoice was marked as paid from the mass-action, there was no date for this action, and so the transaction date would always be empty for "mark as paid" invoices. I assign the paidAt value to the date time the action was triggered.

- I noticed that view routes were not recognizing the corrensponding controller action, this was due to the missing storeId property. That also was added