### PR TITLE
Handle user deletion based on user's invoice status

### DIFF
--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Controllers/PayrollUserController.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Controllers/PayrollUserController.cs
@@ -285,8 +285,8 @@ public class PayrollUserController(
         if (user == null)
             return NotFound();
 
-        var userHasInvoice = ctx.PayrollInvoices.Any(a => a.UserId == user.Id);
-        if (userHasInvoice)
+        if (ctx.PayrollInvoices.Any(a => a.UserId == user.Id &&
+            (a.State != PayrollInvoiceState.Completed && a.State != PayrollInvoiceState.Cancelled)))
         {
             TempData.SetStatusMessageModel(new StatusMessageModel()
             {
@@ -296,7 +296,7 @@ public class PayrollUserController(
             return RedirectToAction(nameof(List), new { storeId = CurrentStore.Id });
         }
 
-        return View("Confirm", new ConfirmModel($"Delete user", $"The user: {user.Name} will be deleted. Are you sure?", "Delete"));
+        return View("Confirm", new ConfirmModel($"Delete user", $"The user: {user.Name} will be deleted alongside all its invoices. Are you sure?", "Delete"));
     }
 
 
@@ -310,9 +310,8 @@ public class PayrollUserController(
         var payrollUser = ctx.PayrollUsers
             .SingleOrDefault(a => a.Id == userId && a.StoreId == CurrentStore.Id);
 
-        var userHasInvoice = ctx.PayrollInvoices.Any(a =>
-        a.UserId == payrollUser.Id);
-        if (userHasInvoice)
+        var userInvoices = ctx.PayrollInvoices.AsNoTracking().Where(a => a.UserId == payrollUser.Id).ToList();
+        if (userInvoices.Any(a => a.State != PayrollInvoiceState.Completed && a.State != PayrollInvoiceState.Cancelled))
         {
             TempData.SetStatusMessageModel(new StatusMessageModel()
             {
@@ -323,6 +322,7 @@ public class PayrollUserController(
         }
 
         ctx.Remove(payrollUser);
+        ctx.RemoveRange(userInvoices);
         await ctx.SaveChangesAsync();
 
         TempData.SetStatusMessageModel(new StatusMessageModel()


### PR DESCRIPTION
Resolves #63 

Previously users cannot be deleted if it has any invoices.

This PR adjusts the implementation allowing deletion of users as long as the user's invoices are either completed or cancelled. 

It also includes a warning to the modal popup informing the admin that the user and its invoices would be deleted.