### PR TITLE
Feat/invoice upload reminders

### DIFF
--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Controllers/PayrollUserController.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Controllers/PayrollUserController.cs
@@ -151,7 +151,7 @@ Thank you,
             };
             try
             {
-                await emailService.SendUserInvitationEmailEmail(dbUser, model.UserInviteEmailSubject, model.UserInviteEmailBody, 
+                await emailService.SendUserInvitationEmail(dbUser, model.UserInviteEmailSubject, model.UserInviteEmailBody, 
                     Url.Action("AcceptInvitation", "Public", new { storeId = CurrentStore.Id, invitation.Token }, Request.Scheme));
             }
             catch (Exception)
@@ -211,7 +211,7 @@ Thank you,
         existingInvitation.CreatedAt = DateTime.UtcNow;
         try
         {
-            await emailService.SendUserInvitationEmailEmail(user, UserInviteEmailSubject, UserInviteEmailBody,
+            await emailService.SendUserInvitationEmail(user, UserInviteEmailSubject, UserInviteEmailBody,
                 Url.Action("AcceptInvitation", "Public", new { storeId = CurrentStore.Id, existingInvitation.Token }, Request.Scheme));
         }
         catch (Exception)
@@ -246,7 +246,7 @@ Thank you,
         if (user.State == PayrollUserState.Pending)
             return NotFound();
 
-        var model = new PayrollUserCreateViewModel { Id = user.Id, Email = user.Email, Name = user.Name };
+        var model = new PayrollUserCreateViewModel { Id = user.Id, Email = user.Email, Name = user.Name, EmailReminder = user.EmailReminder };
         return View(model);
     }
 
@@ -262,6 +262,12 @@ Thank you,
 
         user.Email = string.IsNullOrEmpty(model.Email) ? user.Email : model.Email;
         user.Name = string.IsNullOrEmpty(model.Name) ? user.Name : model.Name;
+
+        user.EmailReminder = string.IsNullOrEmpty(model.EmailReminder)
+        ? user.EmailReminder 
+        : string.Join(",", model.EmailReminder.Split(',')
+                .Select(r => r.Trim()).Where(r => !string.IsNullOrEmpty(r))
+                .Distinct().OrderBy(r => int.Parse(r)));
 
         ctx.Update(user);
         await ctx.SaveChangesAsync();

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Data/Migrations/20250305091505_IncludeEmailRemiderToUser.Designer.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Data/Migrations/20250305091505_IncludeEmailRemiderToUser.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BTCPayServer.RockstarDev.Plugins.Payroll.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BTCPayServer.RockstarDev.Plugins.Payroll.Data.Migrations
 {
     [DbContext(typeof(PayrollPluginDbContext))]
-    partial class PayrollPluginDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250305091505_IncludeEmailRemiderToUser")]
+    partial class IncludeEmailRemiderToUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -84,10 +87,6 @@ namespace BTCPayServer.RockstarDev.Plugins.Payroll.Data.Migrations
                     b.Property<string>("Destination")
                         .HasMaxLength(100)
                         .HasColumnType("character varying(100)");
-
-                    b.Property<string>("ExtraFilenames")
-                        .HasMaxLength(1000)
-                        .HasColumnType("character varying(1000)");
 
                     b.Property<string>("InvoiceFilename")
                         .HasMaxLength(36)

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Data/Migrations/20250305091505_IncludeEmailRemiderToUser.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Data/Migrations/20250305091505_IncludeEmailRemiderToUser.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BTCPayServer.RockstarDev.Plugins.Payroll.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class IncludeEmailRemiderToUser : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "EmailReminder",
+                schema: "BTCPayServer.RockstarDev.Plugins.Payroll",
+                table: "PayrollUsers",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastReminderSent",
+                schema: "BTCPayServer.RockstarDev.Plugins.Payroll",
+                table: "PayrollUsers",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EmailReminder",
+                schema: "BTCPayServer.RockstarDev.Plugins.Payroll",
+                table: "PayrollUsers");
+
+            migrationBuilder.DropColumn(
+                name: "LastReminderSent",
+                schema: "BTCPayServer.RockstarDev.Plugins.Payroll",
+                table: "PayrollUsers");
+        }
+    }
+}

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Data/Models/PayrollUser.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Data/Models/PayrollUser.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
@@ -15,6 +16,8 @@ public class PayrollUser
 
     public string Email { get; set; }
     public string Password { get; set; }
+    public string EmailReminder { get; set; }
+    public DateTime? LastReminderSent { get; set; }
 
     [MaxLength(50)]
     public string StoreId { get; set; }

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Logic/PayrollStoreSetting.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Logic/PayrollStoreSetting.cs
@@ -12,7 +12,10 @@ public class PayrollStoreSetting
     public bool EmailOnInvoicePaid { get; set; }
     public string EmailOnInvoicePaidSubject { get; set; }
     public string EmailOnInvoicePaidBody { get; set; }
-    
+    public bool EmailReminders { get; set; }
+    public string EmailRemindersSubject { get; set; }
+    public string EmailRemindersBody { get; set; }
+
     // automatically set to be referenced in different places
     public string VendorPayPublicLink { get; set; }
 }

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Program.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Program.cs
@@ -2,7 +2,6 @@
 using BTCPayServer.Abstractions.Models;
 using BTCPayServer.RockstarDev.Plugins.Payroll.Data;
 using BTCPayServer.RockstarDev.Plugins.Payroll.Services;
-using BTCPayServer.RockstarDev.Plugins.Payroll.Services.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -23,10 +22,7 @@ public class PayrollPlugin : BaseBTCPayServerPlugin
         serviceCollection.AddSingleton<IHostedService, VendorPayPaidHostedService>();
         serviceCollection.AddSingleton<VendorPayPassHasher>();
         serviceCollection.AddSingleton<EmailService>();
-        
-        // helpers
-        serviceCollection.AddTransient<PayrollInvoiceUploadHelper>();
-        serviceCollection.AddTransient<InvoicesDownloadHelper>();
+        serviceCollection.AddSingleton<IHostedService, VendorPayEmailReminderService>();
 
         // Add the database related registrations
         serviceCollection.AddSingleton<PayrollPluginDbContextFactory>();

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Program.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Program.cs
@@ -2,6 +2,7 @@
 using BTCPayServer.Abstractions.Models;
 using BTCPayServer.RockstarDev.Plugins.Payroll.Data;
 using BTCPayServer.RockstarDev.Plugins.Payroll.Services;
+using BTCPayServer.RockstarDev.Plugins.Payroll.Services.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -23,6 +24,10 @@ public class PayrollPlugin : BaseBTCPayServerPlugin
         serviceCollection.AddSingleton<VendorPayPassHasher>();
         serviceCollection.AddSingleton<EmailService>();
         serviceCollection.AddSingleton<IHostedService, VendorPayEmailReminderService>();
+
+        // helpers
+        serviceCollection.AddTransient<PayrollInvoiceUploadHelper>();
+        serviceCollection.AddTransient<InvoicesDownloadHelper>();
 
         // Add the database related registrations
         serviceCollection.AddSingleton<PayrollPluginDbContextFactory>();

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Services/EmailService.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Services/EmailService.cs
@@ -86,7 +86,7 @@ public class EmailService(EmailSenderFactory emailSender, Logs logs,
         }
     }
 
-    public async Task SendUserInvitationEmailEmail(PayrollUser model, string subject, string body, string vendorPayRegisterationLink)
+    public async Task SendUserInvitationEmail(PayrollUser model, string subject, string body, string vendorPayRegisterationLink)
     {
         var settings = await (await emailSender.GetEmailSender(model.StoreId)).GetEmailSettings();
         if (!settings.IsComplete())
@@ -104,6 +104,24 @@ public class EmailService(EmailSenderFactory emailSender, Logs logs,
         };
         var emailRecipients = new List<EmailRecipient> { recipient };
         await SendBulkEmail(model.StoreId, emailRecipients);
+    }
+
+    public async Task<bool> SendInvoiceEmailReminder(PayrollUser model, string subject, string body)
+    {
+        var settings = await (await emailSender.GetEmailSender(model.StoreId)).GetEmailSettings();
+        if (!settings.IsComplete())
+            return false;
+
+        var storeName = (await storeRepo.FindStore(model.StoreId))?.StoreName;
+        var recipient = new EmailRecipient
+        {
+            Address = InternetAddress.Parse(model.Email),
+            Subject = subject,
+            MessageText = body
+        };
+        var emailRecipients = new List<EmailRecipient> { recipient };
+        await SendBulkEmail(model.StoreId, emailRecipients);
+        return true;
     }
 
     public class EmailRecipient

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Services/VendorPayEmailReminderService.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Services/VendorPayEmailReminderService.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer.HostedServices;
+using BTCPayServer.Logging;
+using BTCPayServer.RockstarDev.Plugins.Payroll.Data;
+using BTCPayServer.RockstarDev.Plugins.Payroll.Data.Models;
+using Microsoft.Extensions.Logging;
+
+namespace BTCPayServer.RockstarDev.Plugins.Payroll.Services;
+
+
+public class VendorPayEmailReminderService(
+    EmailService emailService,
+    EventAggregator eventAggregator,
+    PayrollPluginDbContextFactory payrollPluginDbContextFactory,
+    Logs logs)
+    : EventHostedServiceBase(eventAggregator, logs)
+{
+    public override async Task StartAsync(CancellationToken cancellationToken)
+    {
+
+        await base.StartAsync(cancellationToken);
+        _ = ScheduleChecks();
+    }
+
+    private CancellationTokenSource _checkTcs = new();
+
+    private async Task ScheduleChecks()
+    {
+        while (!CancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                var tcs = new TaskCompletionSource<object>();
+
+                PushEvent(new SequentialExecute(async () =>
+                {
+                    await HandleEmailReminders();
+                    return null;
+
+                }, tcs));
+                await tcs.Task;
+            }
+            catch (Exception e)
+            {
+                Logs.PayServer.LogError(e, "Error while checking email reminder subscriptions");
+            }
+            _checkTcs = new CancellationTokenSource();
+            _checkTcs.CancelAfter(TimeSpan.FromHours(1));
+            try
+            {
+                await Task.Delay(TimeSpan.FromHours(1),
+                    CancellationTokenSource.CreateLinkedTokenSource(_checkTcs.Token, CancellationToken).Token);
+            }
+            catch (OperationCanceledException) { }
+        }
+    }
+
+    protected override void SubscribeToEvents()
+    {
+        Subscribe<SequentialExecute>();
+        base.SubscribeToEvents();
+    }
+
+    public record SequentialExecute(Func<Task<object>> Action, TaskCompletionSource<object> TaskCompletionSource);
+
+    protected override async Task ProcessEvent(object evt, CancellationToken cancellationToken)
+    {
+        if (evt is SequentialExecute sequentialExecute)
+        {
+            var task = await sequentialExecute.Action();
+            sequentialExecute.TaskCompletionSource.SetResult(task);
+            return;
+        }
+
+        await base.ProcessEvent(evt, cancellationToken);
+    }
+
+    private async Task HandleEmailReminders()
+    {
+        bool shouldUpdateDb = false;
+
+        await using var ctx = payrollPluginDbContextFactory.CreateContext();
+        List<PayrollUser> activeUsers = ctx.PayrollUsers.Where(a => a.State == PayrollUserState.Active).ToList();
+
+        DateTime todayDate = DateTime.UtcNow.Date;
+        foreach (var user in activeUsers)
+        {
+            if (user.LastReminderSent.HasValue && user.LastReminderSent.Value.Date == todayDate)
+                continue;
+
+            var settings = await payrollPluginDbContextFactory.GetSettingAsync(user.StoreId);
+            if (settings == null || !settings.EmailReminders || string.IsNullOrEmpty(user.EmailReminder))
+                continue;
+
+            List<int> reminders = user.EmailReminder.Split(',').Select(int.Parse).ToList();
+            if (reminders.Contains(todayDate.Day))
+            {
+                try
+                {
+                    var emailSent = await emailService.SendInvoiceEmailReminder(user, settings.EmailRemindersSubject, settings.EmailRemindersBody);
+                    if (emailSent)
+                    {
+                        user.LastReminderSent = todayDate;
+                        shouldUpdateDb = true;
+                    }
+                }
+                catch (Exception) { }
+            }
+        }
+        if (shouldUpdateDb)
+        {
+            ctx.UpdateRange(activeUsers);
+            await ctx.SaveChangesAsync();
+        }
+    }
+}

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Services/VendorPayPaidHostedService.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Services/VendorPayPaidHostedService.cs
@@ -4,16 +4,13 @@ using BTCPayServer.Logging;
 using BTCPayServer.RockstarDev.Plugins.Payroll.Data;
 using BTCPayServer.RockstarDev.Plugins.Payroll.Data.Models;
 using BTCPayServer.Services.Invoices;
-using BTCPayServer.Services.Stores;
 using Microsoft.EntityFrameworkCore;
-using MimeKit;
 using NBitcoin;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using static BTCPayServer.RockstarDev.Plugins.Payroll.Services.EmailService;
 
 namespace BTCPayServer.RockstarDev.Plugins.Payroll.Services;
 

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/ViewModels/PayrollSettingViewModel.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/ViewModels/PayrollSettingViewModel.cs
@@ -15,6 +15,11 @@ public class PayrollSettingViewModel
     public string EmailOnInvoicePaidSubject { get; set; }
     public string EmailOnInvoicePaidBody { get; set; }
 
+    [Display(Name = "Email reminders for users")]
+    public bool EmailReminders { get; set; }
+    public string EmailRemindersSubject { get; set; }
+    public string EmailRemindersBody { get; set; }
+
     public record Defaults
     {
         public const string EmailOnInvoicePaidSubject = @"Your invoice has been paid";

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/ViewModels/PayrollUserViewModels.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/ViewModels/PayrollUserViewModels.cs
@@ -41,6 +41,9 @@ public class PayrollUserCreateViewModel
     [Display(Name = "Confirm Password")]
     [Compare("Password", ErrorMessage = "Password fields don't match")]
     public string ConfirmPassword { get; set; }
+
+    [Display(Name = "Reminder Dates")]
+    public string EmailReminder { get; set; }
     [JsonIgnore]
     public string StoreId { get; set; }
 }

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Views/PayrollSetting/Settings.cshtml
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Views/PayrollSetting/Settings.cshtml
@@ -108,8 +108,8 @@
             };
 
             toggleElements.forEach(({ toggle, target }) => {
-                const toggleEl = document.getElementById(toggle);
-                toggleEl.addEventListener('change', () => toggleVisibility(toggle, target));
+                const toggleInput = document.getElementById(toggle);
+                toggleInput.addEventListener('change', () => toggleVisibility(toggle, target));
                 toggleVisibility(toggle, target);
             });
         });

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Views/PayrollSetting/Settings.cshtml
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Views/PayrollSetting/Settings.cshtml
@@ -9,6 +9,7 @@
     var storeId = ScopeProvider.GetCurrentStoreId();
     Layout = "_Layout";
     ViewData.SetActivePage("VendorPay", "Update Plugin Settings", "VendorPay");
+    var storeEmailSettingsConfigured = (bool)ViewData["StoreEmailSettingsConfigured"];
 }
 
 <form method="post" asp-action="Settings">
@@ -33,9 +34,6 @@
             </div>
 
             <h3>Emails</h3>
-            @{
-                var storeEmailSettingsConfigured = (bool)ViewData["StoreEmailSettingsConfigured"];
-            }
             <div class="form-group d-flex align-items-center">
                 
                 <input asp-for="EmailOnInvoicePaid" type="checkbox" class="btcpay-toggle me-3" id="emailToggle" disabled="@(storeEmailSettingsConfigured ? null : "disabled")" />
@@ -63,6 +61,35 @@
                     <span asp-validation-for="EmailOnInvoicePaidBody" class="text-danger"></span>
                 </div>
             </div>
+
+            <div class="form-group d-flex align-items-center">
+
+                <input asp-for="EmailReminders" type="checkbox" class="btcpay-toggle me-3" id="emailReminderToggle" disabled="@(storeEmailSettingsConfigured ? null : "disabled")" />
+                <div>
+                    <label asp-for="EmailReminders" class="form-check-label"></label>
+                    <span asp-validation-for="EmailReminders" class="text-danger"></span>
+                    @if (!storeEmailSettingsConfigured)
+                    {
+                        <div class="text-secondary">
+                            <span text-translate="true">Your email server has not been configured.</span>
+                            <a asp-controller="UIStores" asp-action="StoreEmailSettings" text-translate="true" asp-route-storeId="@storeId">Please configure it first.</a>
+                        </div>
+                    }
+                </div>
+            </div>
+
+            <div id="emailReminderTemplateGroup" style="display: none;">
+                <div class="form-group">
+                    <label asp-for="EmailRemindersSubject" class="form-label">Email Reminder Template Subject</label>
+                    <input asp-for="EmailRemindersSubject" class="form-control" />
+                    <span asp-validation-for="EmailRemindersSubject" class="text-danger"></span>
+                </div>
+                <div class="form-group">
+                    <label asp-for="EmailRemindersBody" class="form-label">Customize Email Reminder Template Body</label>
+                    <textarea asp-for="EmailRemindersBody" class="form-control" rows="8"></textarea>
+                    <span asp-validation-for="EmailRemindersBody" class="text-danger"></span>
+                </div>
+            </div>
         </div>
     </div>
 </form>
@@ -71,13 +98,20 @@
 @section PageFootContent {
     <script>
         document.addEventListener('DOMContentLoaded', function () {
-            const emailToggle = document.getElementById('emailToggle');
-            const emailTemplateGroup = document.getElementById('emailTemplateGroup');
-            const toggleEmailTemplateVisibility = () => {
-                emailTemplateGroup.style.display = emailToggle.checked ? 'block' : 'none';
+            const toggleElements = [
+                { toggle: 'emailToggle', target: 'emailTemplateGroup' },
+                { toggle: 'emailReminderToggle', target: 'emailReminderTemplateGroup' }
+            ];
+
+            const toggleVisibility = (toggle, target) => {
+                document.getElementById(target).style.display = document.getElementById(toggle).checked ? 'block' : 'none';
             };
-            emailToggle.addEventListener('change', toggleEmailTemplateVisibility);
-            toggleEmailTemplateVisibility();
+
+            toggleElements.forEach(({ toggle, target }) => {
+                const toggleEl = document.getElementById(toggle);
+                toggleEl.addEventListener('change', () => toggleVisibility(toggle, target));
+                toggleVisibility(toggle, target);
+            });
         });
     </script>
 }

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Views/PayrollUser/Edit.cshtml
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Views/PayrollUser/Edit.cshtml
@@ -5,8 +5,22 @@
 @model PayrollUserCreateViewModel
 @{
     ViewData.SetActivePage("VendorPay", "Edit Vendor Pay User", "VendorPay");
-    
     var storeId = ScopeProvider.GetCurrentStoreId();
+
+    bool IsValidReminderDate(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return false;
+        if (int.TryParse(value, out int num))
+        {
+            return num >= 1 && num <= 31;
+        }
+        return false;
+    }
+
+    var initialReminders = (Model.EmailReminder ?? "").Split(',')
+        .Where(r => !string.IsNullOrWhiteSpace(r)).Select(r => r.Trim())
+        .Where(IsValidReminderDate).Distinct()
+        .OrderBy(r => int.Parse(r)).ToList();
 }
 
 <form method="post" asp-action="Edit">
@@ -39,6 +53,94 @@
                     </div>
                 </div>
             </div>
+
+
+            <div class="form-group">
+                <label asp-for="EmailReminder" class="form-label"></label>
+                <div class="input-group mb-3">
+                    <input type="number" id="reminderInput" class="form-control" placeholder="Enter date (1-31)" min="1" max="31" />
+                    <button type="button" id="addReminder" class="btn btn-secondary">Add</button>
+                </div>
+                <div id="reminderList" class="d-flex flex-wrap align-items-center gap-2">
+                    @foreach (var reminder in initialReminders)
+                    {
+                        <span class="badge bg-secondary me-1 mb-1 role-button cursor-pointer" data-value="@reminder">
+                            @reminder
+                        </span>
+                    }
+                </div>
+                <input type="hidden" id="EmailReminder" asp-for="EmailReminder" value="@string.Join(",", initialReminders)" />
+                <div id="validationMessage" class="text-danger mt-2"></div>
+            </div>
+
         </div>
     </div>
 </form>
+
+@section PageFootContent {
+    <script>
+        document.addEventListener("DOMContentLoaded", function () {
+            const reminderInput = document.getElementById("reminderInput");
+            const addReminderButton = document.getElementById("addReminder");
+            const reminderList = document.getElementById("reminderList");
+            const hiddenInput = document.getElementById("EmailReminder");
+            const validationMessage = document.getElementById("validationMessage");
+
+            function isValidReminderDate(value) {
+                const num = parseInt(value, 10);
+                return !isNaN(num) && num >= 1 && num <= 31;
+            }
+
+            function updateHiddenInput() {
+                const selectedValues = Array.from(reminderList.querySelectorAll(".role-button"))
+                    .map(badge => badge.getAttribute("data-value"))
+                    .filter(val => val);
+                hiddenInput.value = selectedValues.join(",");
+            }
+
+            addReminderButton.addEventListener("click", function () {
+                const value = reminderInput.value.trim();
+
+                if (!value) {
+                    validationMessage.textContent = "Please enter a date";
+                    return;
+                }
+
+                if (!isValidReminderDate(value)) {
+                    validationMessage.textContent = "Please enter a valid date between 1 and 31";
+                    return;
+                }
+
+                const existingValues = hiddenInput.value.split(",");
+                if (existingValues.includes(value)) {
+                    validationMessage.textContent = "This date is already added";
+                    return;
+                }
+
+                const badge = document.createElement("span");
+                badge.classList.add("badge", "bg-secondary", "me-1", "mb-1", "role-button");
+                badge.setAttribute("data-value", value);
+                badge.textContent = value;
+
+                reminderList.appendChild(badge);
+                updateHiddenInput();
+                reminderInput.value = "";
+                validationMessage.textContent = "";
+            });
+
+            reminderInput.addEventListener("keypress", function (e) {
+                if (e.key === "Enter") {
+                    e.preventDefault();
+                    addReminderButton.click();
+                }
+            });
+
+            reminderList.addEventListener("click", function (e) {
+                if (e.target.classList.contains("role-button")) {
+                    e.target.remove();
+                updateHiddenInput();
+                }
+            });
+        });
+    </script>
+}

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Views/PayrollUser/Edit.cshtml
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Views/PayrollUser/Edit.cshtml
@@ -57,6 +57,9 @@
 
             <div class="form-group">
                 <label asp-for="EmailReminder" class="form-label"></label>
+                <div class="text-secondary">
+                    <span>Set invoice reminder days for user. Remember to enable Email reminder in settings page</span>
+                </div>
                 <div class="input-group mb-3">
                     <input type="number" id="reminderInput" class="form-control" placeholder="Enter date (1-31)" min="1" max="31" />
                     <button type="button" id="addReminder" class="btn btn-secondary">Add</button>

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Views/PayrollUser/List.cshtml
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Views/PayrollUser/List.cshtml
@@ -7,7 +7,6 @@
 @{
     Layout = "_Layout"; // adding so PageFootContent section is detected
     ViewData.SetActivePage("VendorPay", "Vendor Pay Users", "VendorPay");
-
     var storeId = ScopeProvider.GetCurrentStoreId();
 }
 
@@ -64,6 +63,7 @@
                     <tr>
                         <th scope="col">Name</th>
                         <th scope="col">Email</th>
+                        <th scope="col">Email Reminder Days</th>
                         <th scope="col">State</th>
                         <th scope="col" class="text-end"></th>
                     </tr>
@@ -74,6 +74,7 @@
                         <tr class="mass-action-row">
                             <td>@pp.Name</td>
                             <td>@pp.Email</td>
+                            <td>@(!string.IsNullOrEmpty(pp.EmailReminder) ? pp.EmailReminder : "-")</td>
                             <td>@pp.State</td>
                             <td class="align-middle">
                             </td>


### PR DESCRIPTION
Resolves #65 

![EmailReminderFlow](https://github.com/user-attachments/assets/d7e81f01-f87b-4f47-9abf-49711c1f3e83)


![image](https://github.com/user-attachments/assets/09e12307-12a3-408d-9554-1ac22716bc98)


Task Implemented:

Added two new properties: string field EmailReminder to store a comma-separated list of numbers (e.g., 15,31), DateTime LastReminderSent

Ensured whitespace is removed on saving to maintain consistency (so 15, 31 turns into 15,31)

Modified PayrollSettingsViewModel to include Email reminder properties

Allowed user setup email reminder on Vendor pay setting

Email content is customizable using EmailRemindersSubject and EmailRemindersBody.

Provided Admin with ability to Edit user's reminder dates (add multiple and also remove existing)

Validates and sanitizes input, to prevent invalid date input (e.g., 0, 32)

On each date specified in EmailReminder, send an email reminder to the user as long as Email Reminders in vendor pay setting is true


Todo:

If the month doesn’t have 31 days, send the reminder on the last available date (27th, 28th, or 30th).