### PR TITLE
Vendor-plugin/csv report update

### DIFF
--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Controllers/PayrollInvoiceController.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Controllers/PayrollInvoiceController.cs
@@ -37,7 +37,6 @@ namespace BTCPayServer.RockstarDev.Plugins.Payroll.Controllers;
 public class PayrollInvoiceController(
     PluginDbContextFactory pluginDbContextFactory,
     DefaultRulesCollection defaultRulesCollection,
-    InvoiceRepository invoiceRepository,
     RateFetcher rateFetcher,
     PaymentMethodHandlerDictionary handlers,
     BTCPayNetworkProvider networkProvider,
@@ -63,11 +62,6 @@ public class PayrollInvoiceController(
             .OrderByDescending(data => data.CreatedAt).ToListAsync();
 
         if (!all) payrollInvoices = payrollInvoices.Where(a => a.User.State == PayrollUserState.Active).ToList();
-
-        /*if (payrollInvoices.Count > 0)
-        {
-            var invoice = await invoiceRepository.GetInvoice(payrollInvoices.First().Id);
-        }*/
 
         // triggering saving of admin user id if needed
         var adminset = await settingsRepository.GetSettingAsync<PayrollPluginSettings>();


### PR DESCRIPTION
Resolve #91 


- Remove BTCJPY Rate from the file header and renamed BTCUSD Rate to BTC-Currency Rate since currency can be any other currency and the rate calculation is based on the amount currency.

- Display amount in BTC instead of balance as requested in the issue tagged