### PR TITLE
[Fix] Remember email on VendorPay login

### DIFF
--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Controllers/PublicController.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Controllers/PublicController.cs
@@ -172,7 +172,7 @@ public class PublicController(
         {
             cookies.Append(VendorpayEmailCookieName, model.Email.Trim(), new CookieOptions
             {
-                Expires = DateTimeOffset.UtcNow.AddDays(30),
+                Expires = DateTimeOffset.UtcNow.AddDays(60),
                 HttpOnly = true,
                 IsEssential = true,
                 SameSite = SameSiteMode.Lax,


### PR DESCRIPTION
 ## Changes

  - Save remembered email in a cookie on successful public login.
  - Pre-fill login email from cookie on the public login page.