### PR TITLE
Payroll: Include filter by status in category dropdown

### DIFF
--- a/BTCPayServer.Plugins.Tests/BTCPayServer.Plugins.Tests.csproj
+++ b/BTCPayServer.Plugins.Tests/BTCPayServer.Plugins.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0"/>
         <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.48.0"/>
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
@@ -33,6 +33,9 @@
             <PrivateAssets>all</PrivateAssets>
         </ProjectReference>
         <ProjectReference Include="..\Plugins\BTCPayServer.RockstarDev.Plugins.LnurlVerify\BTCPayServer.RockstarDev.Plugins.LnurlVerify.csproj" />
+        <ProjectReference Include="..\Plugins\BTCPayServer.RockstarDev.Plugins.Payroll\BTCPayServer.RockstarDev.Plugins.Payroll.csproj">
+            <PrivateAssets>all</PrivateAssets>
+        </ProjectReference>
     </ItemGroup>
 
 </Project>

--- a/BTCPayServer.Plugins.Tests/VendorPayTests/EnumExtensionsTests.cs
+++ b/BTCPayServer.Plugins.Tests/VendorPayTests/EnumExtensionsTests.cs
@@ -1,0 +1,48 @@
+using System.ComponentModel.DataAnnotations;
+using BTCPayServer.RockstarDev.Plugins.VendorPay.Data.Models;
+using BTCPayServer.RockstarDev.Plugins.VendorPay.Services.Helpers;
+using Xunit;
+
+namespace BTCPayServer.Plugins.Tests.VendorPayTests;
+
+public class EnumExtensionsTests
+{
+    [Theory]
+    [InlineData(VendorPayInvoiceState.AwaitingApproval, "Awaiting Approval")]
+    [InlineData(VendorPayInvoiceState.AwaitingPayment, "Awaiting Payment")]
+    [InlineData(VendorPayInvoiceState.InProgress, "In Progress")]
+    [InlineData(VendorPayInvoiceState.Completed, "Completed")]
+    [InlineData(VendorPayInvoiceState.Cancelled, "Cancelled")]
+    public void GetDisplayName_ReadsDisplayAttribute(VendorPayInvoiceState value, string expected)
+    {
+        Assert.Equal(expected, value.GetDisplayName());
+    }
+
+    [Fact]
+    public void GetDisplayName_FallsBackToEnumName_WhenNoDisplayAttribute()
+    {
+        Assert.Equal(nameof(BareEnum.Foo), BareEnum.Foo.GetDisplayName());
+        Assert.Equal(nameof(BareEnum.Bar), BareEnum.Bar.GetDisplayName());
+    }
+
+    [Fact]
+    public void GetDisplayName_FallsBackToEnumName_WhenDisplayAttributeHasNullName()
+    {
+        Assert.Equal(nameof(MixedEnum.Tagged), MixedEnum.Tagged.GetDisplayName());
+        Assert.Equal("Friendly", MixedEnum.WithName.GetDisplayName());
+    }
+
+    private enum BareEnum
+    {
+        Foo,
+        Bar
+    }
+
+    private enum MixedEnum
+    {
+        [Display]
+        Tagged,
+        [Display(Name = "Friendly")]
+        WithName
+    }
+}

--- a/BTCPayServer.Plugins.Tests/VendorPayTests/VendorPayPluginUITest.cs
+++ b/BTCPayServer.Plugins.Tests/VendorPayTests/VendorPayPluginUITest.cs
@@ -717,59 +717,6 @@ public class VendorPayPluginUITest : PlaywrightBaseTest
     }
 
     [Fact]
-    public async Task PayByStatus_FiltersInvoicesCorrectly()
-    {
-        await InitializePlaywright(ServerTester);
-        var user = ServerTester.NewAccount();
-        await user.GrantAccessAsync();
-        await user.MakeAdmin();
-        await GoToUrl("/login");
-        await LogIn(user.RegisterDetails.Email, user.RegisterDetails.Password);
-        await GoToUrl($"/stores/{user.StoreId}/onchain/BTC");
-        await AddDerivationScheme();
-
-        await GoToUrl($"/plugins/{user.StoreId}/vendorpay/list");
-        await MakeInvoiceFileUploadOptional();
-
-        await Page.GetByRole(AriaRole.Link, new PageGetByRoleOptions { NameString = "Admin Upload Invoice" }).ClickAsync();
-        await CreateVendorPayInvoice("bcrt1qzyzvsqjqn9xzzdgcqhp8c2k9fm5x2napw00v9d");
-
-        await GoToUrl($"/plugins/{user.StoreId}/vendorpay/list");
-
-        var filterBtn = Page.Locator("button#combinedFilterBtn");
-        Assert.True(await filterBtn.CountAsync() > 0, "Combined filter button not found");
-        await filterBtn.ClickAsync();
-
-        var awaitingApprovalOption = Page.Locator(".dropdown-menu .dropdown-item", new PageLocatorOptions { HasTextString = "Awaiting Approval" });
-        Assert.True(await awaitingApprovalOption.CountAsync() > 0, "Awaiting Approval status option not found");
-        await awaitingApprovalOption.ClickAsync();
-
-        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-
-        Assert.Contains("statusFilter=AwaitingApproval", Page.Url);
-
-        var filterBtnText = await filterBtn.TextContentAsync();
-        Assert.Contains("Awaiting Approval", filterBtnText?.Trim());
-
-        var allRows = Page.Locator("tbody tr.mass-action-row");
-        var rowCount = await allRows.CountAsync();
-        Assert.True(rowCount >= 1, "Expected at least 1 row after status filter");
-
-        for (int i = 0; i < rowCount; i++)
-        {
-            var stateCell = allRows.Nth(i).Locator("td:nth-child(6)");
-            var stateText = await stateCell.TextContentAsync();
-            Assert.Contains("AwaitingApproval", stateText?.Trim());
-        }
-
-        await filterBtn.ClickAsync();
-        var noneOption = Page.Locator(".dropdown-menu .dropdown-item", new PageLocatorOptions { HasTextString = "None" });
-        await noneOption.ClickAsync();
-        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-        Assert.DoesNotContain("statusFilter=", Page.Url);
-    }
-
-    [Fact]
     public async Task AccountlessInvoiceUpload_SecurityScenarios()
     {
         await InitializePlaywright(ServerTester);

--- a/BTCPayServer.Plugins.Tests/VendorPayTests/VendorPayPluginUITest.cs
+++ b/BTCPayServer.Plugins.Tests/VendorPayTests/VendorPayPluginUITest.cs
@@ -687,12 +687,15 @@ public class VendorPayPluginUITest : PlaywrightBaseTest
         var awaitingCount = await awaitingRows.CountAsync();
         Assert.True(awaitingCount >= 2, $"Expected at least 2 AwaitingApproval invoices, found {awaitingCount}");
 
-        var filterBtn = Page.Locator("button#labelFilterBtn");
-        Assert.True(await filterBtn.CountAsync() > 0, "Filter by Label button not found");
+        var filterBtn = Page.Locator("button#combinedFilterBtn");
+        Assert.True(await filterBtn.CountAsync() > 0, "Combined filter button not found");
         await filterBtn.ClickAsync();
-        var staffOption = Page.Locator(".dropdown-menu .dropdown-item.label-filter-item", new PageLocatorOptions { HasTextString = "Staff" });
-        Assert.True(await staffOption.CountAsync() > 0, "Staff label not found in Filter by Label dropdown");
+
+        var staffOption = Page.Locator(".dropdown-menu .dropdown-item", new PageLocatorOptions { HasTextString = "Staff" });
+        Assert.True(await staffOption.CountAsync() > 0, "Staff label not found in filter dropdown");
         await staffOption.ClickAsync();
+
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
         var checkedBoxes = Page.Locator("input.mass-action-select:checked");
         var checkedCount = await checkedBoxes.CountAsync();
@@ -711,6 +714,57 @@ public class VendorPayPluginUITest : PlaywrightBaseTest
         var alert = await FindAlertMessageAsync(StatusMessageModel.StatusSeverity.Info);
         var alertText = (await alert.TextContentAsync())?.Trim();
         Assert.Contains("2 invoices", alertText, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task PayByStatus_FiltersInvoicesCorrectly()
+    {
+        await InitializePlaywright(ServerTester);
+        var user = ServerTester.NewAccount();
+        await user.GrantAccessAsync();
+        await user.MakeAdmin();
+        await GoToUrl("/login");
+        await LogIn(user.RegisterDetails.Email, user.RegisterDetails.Password);
+
+        await GoToUrl($"/plugins/{user.StoreId}/vendorpay/list");
+        await MakeInvoiceFileUploadOptional();
+
+        await Page.GetByRole(AriaRole.Link, new PageGetByRoleOptions { NameString = "Admin Upload Invoice" }).ClickAsync();
+        await CreateVendorPayInvoice("bcrt1qzyzvsqjqn9xzzdgcqhp8c2k9fm5x2napw00v9d");
+
+        await GoToUrl($"/plugins/{user.StoreId}/vendorpay/list");
+
+        var filterBtn = Page.Locator("button#combinedFilterBtn");
+        Assert.True(await filterBtn.CountAsync() > 0, "Combined filter button not found");
+        await filterBtn.ClickAsync();
+
+        var awaitingApprovalOption = Page.Locator(".dropdown-menu .dropdown-item", new PageLocatorOptions { HasTextString = "Awaiting Approval" });
+        Assert.True(await awaitingApprovalOption.CountAsync() > 0, "Awaiting Approval status option not found");
+        await awaitingApprovalOption.ClickAsync();
+
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        Assert.Contains("statusFilter=AwaitingApproval", Page.Url);
+
+        var filterBtnText = await filterBtn.TextContentAsync();
+        Assert.Contains("Awaiting Approval", filterBtnText?.Trim());
+
+        var allRows = Page.Locator("tbody tr.mass-action-row");
+        var rowCount = await allRows.CountAsync();
+        Assert.True(rowCount >= 1, "Expected at least 1 row after status filter");
+
+        for (int i = 0; i < rowCount; i++)
+        {
+            var stateCell = allRows.Nth(i).Locator("td:nth-child(6)");
+            var stateText = await stateCell.TextContentAsync();
+            Assert.Contains("AwaitingApproval", stateText?.Trim());
+        }
+
+        await filterBtn.ClickAsync();
+        var noneOption = Page.Locator(".dropdown-menu .dropdown-item", new PageLocatorOptions { HasTextString = "None" });
+        await noneOption.ClickAsync();
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        Assert.DoesNotContain("statusFilter=", Page.Url);
     }
 
     [Fact]

--- a/BTCPayServer.Plugins.Tests/VendorPayTests/VendorPayPluginUITest.cs
+++ b/BTCPayServer.Plugins.Tests/VendorPayTests/VendorPayPluginUITest.cs
@@ -725,6 +725,8 @@ public class VendorPayPluginUITest : PlaywrightBaseTest
         await user.MakeAdmin();
         await GoToUrl("/login");
         await LogIn(user.RegisterDetails.Email, user.RegisterDetails.Password);
+        await GoToUrl($"/stores/{user.StoreId}/onchain/BTC");
+        await AddDerivationScheme();
 
         await GoToUrl($"/plugins/{user.StoreId}/vendorpay/list");
         await MakeInvoiceFileUploadOptional();

--- a/BTCPayServer.Plugins.Tests/VendorPayTests/VendorPayPluginUITest.cs
+++ b/BTCPayServer.Plugins.Tests/VendorPayTests/VendorPayPluginUITest.cs
@@ -717,6 +717,99 @@ public class VendorPayPluginUITest : PlaywrightBaseTest
     }
 
     [Fact]
+    public async Task FilterByStatus_ShowsOnlyMatchingInvoices()
+    {
+        await InitializePlaywright(ServerTester);
+        var user = ServerTester.NewAccount();
+        await user.GrantAccessAsync();
+        await user.MakeAdmin();
+        await GoToUrl("/login");
+        await LogIn(user.RegisterDetails.Email, user.RegisterDetails.Password);
+
+        await GoToUrl($"/plugins/{user.StoreId}/vendorpay/users/list");
+        await CreateVendorPayUser();
+        await FindAlertMessageAsync(StatusMessageModel.StatusSeverity.Success);
+
+        await GoToUrl($"/plugins/{user.StoreId}/vendorpay/list");
+        await MakeInvoiceFileUploadOptional();
+
+        await Page.GetByRole(AriaRole.Link, new PageGetByRoleOptions { NameString = "Admin Upload Invoice" }).ClickAsync();
+        await CreateVendorPayInvoice("bcrt1qzyzvsqjqn9xzzdgcqhp8c2k9fm5x2napw00v9d");
+        await Page.GetByRole(AriaRole.Link, new PageGetByRoleOptions { NameString = "Admin Upload Invoice" }).ClickAsync();
+        await CreateVendorPayInvoice("bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw");
+
+        await GoToUrl($"/plugins/{user.StoreId}/vendorpay/list");
+        var awaitingRowsBefore = Page.Locator("tbody tr.mass-action-row", new PageLocatorOptions { HasTextString = "AwaitingApproval" });
+        Assert.True(await awaitingRowsBefore.CountAsync() >= 2,
+            "Expected at least 2 AwaitingApproval invoices to seed the filter test");
+
+        var filterBtn = Page.Locator("button#combinedFilterBtn");
+        Assert.True(await filterBtn.CountAsync() > 0, "Combined filter button not found");
+        await filterBtn.ClickAsync();
+
+        var awaitingApprovalOption = Page.Locator(".dropdown-menu .dropdown-item",
+            new PageLocatorOptions { HasTextString = "Awaiting Approval" });
+        Assert.True(await awaitingApprovalOption.CountAsync() > 0,
+            "'Awaiting Approval' status option not found in filter dropdown");
+        await awaitingApprovalOption.First.ClickAsync();
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var url = Page.Url;
+        Assert.Contains("statusFilter=AwaitingApproval", url, StringComparison.OrdinalIgnoreCase);
+
+        var awaitingRowsAfter = Page.Locator("tbody tr.mass-action-row", new PageLocatorOptions { HasTextString = "AwaitingApproval" });
+        Assert.True(await awaitingRowsAfter.CountAsync() >= 2,
+            "Expected awaiting-approval invoices to remain visible after filter applied");
+
+        var filterBtnText = await Page.Locator("button#combinedFilterBtn").TextContentAsync();
+        Assert.Contains("Awaiting Approval", filterBtnText ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task FilterByStatus_PreservedAcrossActiveAllTabs()
+    {
+        await InitializePlaywright(ServerTester);
+        var user = ServerTester.NewAccount();
+        await user.GrantAccessAsync();
+        await user.MakeAdmin();
+        await GoToUrl("/login");
+        await LogIn(user.RegisterDetails.Email, user.RegisterDetails.Password);
+
+        await GoToUrl($"/plugins/{user.StoreId}/vendorpay/users/list");
+        await CreateVendorPayUser();
+        await FindAlertMessageAsync(StatusMessageModel.StatusSeverity.Success);
+
+        await GoToUrl($"/plugins/{user.StoreId}/vendorpay/list");
+        await MakeInvoiceFileUploadOptional();
+        await Page.GetByRole(AriaRole.Link, new PageGetByRoleOptions { NameString = "Admin Upload Invoice" }).ClickAsync();
+        await CreateVendorPayInvoice("bcrt1qzyzvsqjqn9xzzdgcqhp8c2k9fm5x2napw00v9d");
+
+        // Apply the status filter on the Active tab via direct URL (avoids dropdown UI flake).
+        await GoToUrl($"/plugins/{user.StoreId}/vendorpay/list?statusFilter=AwaitingApproval");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var allTab = Page.Locator("a#all-view");
+        Assert.True(await allTab.CountAsync() > 0, "All-view tab not found");
+        await allTab.ClickAsync();
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var afterUrl = Page.Url;
+        Assert.Contains("all=true", afterUrl, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("statusFilter=AwaitingApproval", afterUrl, StringComparison.OrdinalIgnoreCase);
+
+        var filterBtnText = await Page.Locator("button#combinedFilterBtn").TextContentAsync();
+        Assert.Contains("Awaiting Approval", filterBtnText ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+
+        // And back to Active - filter must still survive.
+        var activeTab = Page.Locator("a#active-view");
+        await activeTab.ClickAsync();
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var backUrl = Page.Url;
+        Assert.Contains("statusFilter=AwaitingApproval", backUrl, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task AccountlessInvoiceUpload_SecurityScenarios()
     {
         await InitializePlaywright(ServerTester);

--- a/ConfigBuilder/ConfigBuilder.csproj
+++ b/ConfigBuilder/ConfigBuilder.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.AdminPassReset/BTCPayServer.RockstarDev.Plugins.AdminPassReset.csproj
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.AdminPassReset/BTCPayServer.RockstarDev.Plugins.AdminPassReset.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>12</LangVersion>
     </PropertyGroup>
     <!-- -->

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.BitcoinStacker/BTCPayServer.RockstarDev.Plugins.BitcoinStacker.csproj
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.BitcoinStacker/BTCPayServer.RockstarDev.Plugins.BitcoinStacker.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>12</LangVersion>
     </PropertyGroup>
     <!-- -->
@@ -41,11 +41,11 @@
 
 
     <ItemGroup Condition="'$(Configuration)' != 'Release'">
-        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.10.0"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11"/>
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.3.0"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.4"/>
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1"/>
     </ItemGroup>
 
 

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.LnurlVerify/BTCPayServer.RockstarDev.Plugins.LnurlVerify.csproj
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.LnurlVerify/BTCPayServer.RockstarDev.Plugins.LnurlVerify.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>12</LangVersion>
     </PropertyGroup>
     <!-- -->
@@ -37,10 +37,10 @@
 
     <!-- EF Core design-time tools (excluded from Release builds to avoid CodeAnalysis version conflicts) -->
     <ItemGroup Condition="'$(Configuration)' != 'Release'">
-        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.10.0"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11"/>
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.3.0"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.4"/>
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1"/>
     </ItemGroup>
 </Project>

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.MarkPaidCheckout/BTCPayServer.RockstarDev.Plugins.MarkPaidCheckout.csproj
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.MarkPaidCheckout/BTCPayServer.RockstarDev.Plugins.MarkPaidCheckout.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>12</LangVersion>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/BTCPayServer.RockstarDev.Plugins.Payroll.csproj
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/BTCPayServer.RockstarDev.Plugins.Payroll.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>12</LangVersion>
     <RootNamespace>BTCPayServer.RockstarDev.Plugins.VendorPay</RootNamespace>
   </PropertyGroup>
@@ -46,10 +46,10 @@
   </Target>
   -->
   <ItemGroup Condition="'$(Configuration)' != 'Release'">
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.10.0"/>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0"/>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0"/>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11"/>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.3.0"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.4"/>
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0"/>
   </ItemGroup>
 </Project>

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/BTCPayServer.RockstarDev.Plugins.Payroll.csproj
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/BTCPayServer.RockstarDev.Plugins.Payroll.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>12</LangVersion>
     <RootNamespace>BTCPayServer.RockstarDev.Plugins.VendorPay</RootNamespace>
   </PropertyGroup>
@@ -46,10 +46,10 @@
   </Target>
   -->
   <ItemGroup Condition="'$(Configuration)' != 'Release'">
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.3.0"/>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0"/>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0"/>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.4"/>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.10.0"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11"/>
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11"/>
   </ItemGroup>
 </Project>

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/BTCPayServer.RockstarDev.Plugins.Payroll.csproj
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/BTCPayServer.RockstarDev.Plugins.Payroll.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>12</LangVersion>
     <RootNamespace>BTCPayServer.RockstarDev.Plugins.VendorPay</RootNamespace>
   </PropertyGroup>
@@ -46,10 +46,10 @@
   </Target>
   -->
   <ItemGroup Condition="'$(Configuration)' != 'Release'">
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.10.0"/>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0"/>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0"/>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11"/>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.3.0"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.4"/>
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1"/>
   </ItemGroup>
 </Project>

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Controllers/VendorPayInvoiceController.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Controllers/VendorPayInvoiceController.cs
@@ -45,14 +45,13 @@ public class VendorPayInvoiceController(
     private StoreData CurrentStore => HttpContext.GetStoreData();
 
     [HttpGet("list")]
-    public async Task<IActionResult> List(string storeId, bool all, string searchTerm = null)
+    public async Task<IActionResult> List(string storeId, bool all, string searchTerm = null, string statusFilter = null, string labelFilter = null)
     {
         await using var ctx = pluginDbContextFactory.CreateContext();
         var query = ctx.PayrollInvoices
             .Include(data => data.User)
             .Where(p => p.User.StoreId == storeId && !p.IsArchived);
 
-        // Apply search filter if provided
         if (!string.IsNullOrWhiteSpace(searchTerm))
         {
             var search = searchTerm.Trim().ToLower();
@@ -62,6 +61,11 @@ public class VendorPayInvoiceController(
                 (p.Description != null && p.Description.ToLower().Contains(search)) ||
                 p.User.Name.ToLower().Contains(search) ||
                 p.User.Email.ToLower().Contains(search));
+        }
+
+        if (!string.IsNullOrWhiteSpace(statusFilter) && Enum.TryParse<VendorPayInvoiceState>(statusFilter, out var parsedStatus))
+        {
+            query = query.Where(p => p.State == parsedStatus);
         }
 
         var payrollInvoices = await query.OrderByDescending(data => data.CreatedAt).ToListAsync();
@@ -101,12 +105,20 @@ public class VendorPayInvoiceController(
             ))
             .Where(l => l.Count > 0).OrderBy(l => l.Label).ToArray();
 
+        if (!string.IsNullOrWhiteSpace(labelFilter) && labelToUserIds.ContainsKey(labelFilter))
+        {
+            var allowedUserIds = new HashSet<string>(labelToUserIds[labelFilter]);
+            payrollInvoices = payrollInvoices.Where(i => allowedUserIds.Contains(i.UserId)).ToList();
+        }
+
         var model = new VendorPayInvoiceListViewModel
         {
             All = all,
             LabelUserIds = labelToUserIds,
             AllLabels = allLabels,
             SearchTerm = searchTerm,
+            StatusFilter = statusFilter,
+            LabelFilter = labelFilter,
             PurchaseOrdersRequired = settings.PurchaseOrdersRequired,
             VendorPayInvoices = payrollInvoices.Select(tuple => new VendorPayInvoiceViewModel
             {

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Controllers/VendorPayInvoiceController.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Controllers/VendorPayInvoiceController.cs
@@ -63,9 +63,13 @@ public class VendorPayInvoiceController(
                 p.User.Email.ToLower().Contains(search));
         }
 
-        if (!string.IsNullOrWhiteSpace(statusFilter) && Enum.TryParse<VendorPayInvoiceState>(statusFilter, out var parsedStatus))
+        string normalizedStatusFilter = null;
+        if (!string.IsNullOrWhiteSpace(statusFilter)
+            && Enum.TryParse<VendorPayInvoiceState>(statusFilter, ignoreCase: true, out var parsedStatus)
+            && Enum.IsDefined(typeof(VendorPayInvoiceState), parsedStatus))
         {
             query = query.Where(p => p.State == parsedStatus);
+            normalizedStatusFilter = parsedStatus.ToString();
         }
 
         var payrollInvoices = await query.OrderByDescending(data => data.CreatedAt).ToListAsync();
@@ -117,7 +121,7 @@ public class VendorPayInvoiceController(
             LabelUserIds = labelToUserIds,
             AllLabels = allLabels,
             SearchTerm = searchTerm,
-            StatusFilter = statusFilter,
+            StatusFilter = normalizedStatusFilter,
             LabelFilter = labelFilter,
             PurchaseOrdersRequired = settings.PurchaseOrdersRequired,
             VendorPayInvoices = payrollInvoices.Select(tuple => new VendorPayInvoiceViewModel

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Data/Models/PayrollInvoice.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Data/Models/PayrollInvoice.cs
@@ -65,9 +65,14 @@ public class PayrollInvoice
 
 public enum VendorPayInvoiceState
 {
+    [Display(Name = "Awaiting Approval")]
     AwaitingApproval,
+    [Display(Name = "Awaiting Payment")]
     AwaitingPayment,
+    [Display(Name = "In Progress")]
     InProgress, // waiting for confirmation on blockchain (or for lightning it can be stuck HTLC)
+    [Display(Name = "Completed")]
     Completed,
+    [Display(Name = "Cancelled")]
     Cancelled
 }

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Program.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Program.cs
@@ -36,7 +36,7 @@ public class VendorPayPlugin : BaseBTCPayServerPlugin
         serviceCollection.AddSingleton<IHostedService, VendorPayPaidHostedService>();
         serviceCollection.AddSingleton<IHostedService>(provider =>
             provider.GetService<VendorPayEmailReminderService>());
-        serviceCollection.AddScheduledTask<VendorPayEmailReminderService>(TimeSpan.FromHours(12));
+        serviceCollection.AddScheduledTask<VendorPayEmailReminderService>(TimeSpan.FromHours(12.0));
 
         // helpers
         serviceCollection.AddTransient<VendorPayInvoiceUploadHelper>();

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Services/Helpers/EnumExtensions.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Services/Helpers/EnumExtensions.cs
@@ -1,0 +1,17 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+
+namespace BTCPayServer.RockstarDev.Plugins.VendorPay.Services.Helpers;
+
+public static class EnumExtensions
+{
+    public static string GetDisplayName(this Enum value)
+    {
+        var name = value.ToString();
+        var member = value.GetType().GetField(name);
+        if (member is null) return name;
+        var display = member.GetCustomAttribute<DisplayAttribute>();
+        return display?.Name ?? name;
+    }
+}

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/ViewModels/VendorPayInvoiceViewModels.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/ViewModels/VendorPayInvoiceViewModels.cs
@@ -13,6 +13,8 @@ public class VendorPayInvoiceListViewModel
 {
     public bool All { get; set; }
     public string SearchTerm { get; set; }
+    public string StatusFilter { get; set; }
+    public string LabelFilter { get; set; }
     public List<VendorPayInvoiceViewModel> VendorPayInvoices { get; set; }
     public bool PurchaseOrdersRequired { get; set; }
     public (string Label, string Color, int Count)[] AllLabels { get; set; } = Array.Empty<(string, string, int)>();

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Views/VendorPayInvoice/List.cshtml
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Views/VendorPayInvoice/List.cshtml
@@ -50,57 +50,102 @@
 
 <partial name="_StatusMessage" />
 
+
 <div class="row mb-2">
-    @if (Model.AllLabels.Any())
-    {
-        <div class="col-auto d-flex align-items-center gap-2">
-            <span class="text-secondary small">Invoices by label:</span>
-            <div class="dropdown">
-                <button class="btn btn-secondary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" id="labelFilterBtn">
-                    None
-                </button>
-                <ul class="dropdown-menu">
-                    <li>
-                        <a class="dropdown-item" href="#" id="clearLabelFilter">None</a>
-                    </li>
-                    <li>
-                        <hr class="dropdown-divider" />
-                    </li>
-                    @foreach (var (label, _, count) in Model.AllLabels)
-                    {
-                        <li>
-                            <a class="dropdown-item d-flex justify-content-between align-items-center label-filter-item"
-                               href="#" data-label="@label">
-                                <span>@label</span>
-                                <span class="badge bg-secondary ms-2">@count</span>
-                            </a>
-                        </li>
-                    }
-                </ul>
-            </div>
-        </div>
-    }
-    <div class="col-lg-6 ms-auto">
-        <form method="get" asp-action="List" asp-route-storeId="@storeId" asp-route-all="@Model.All">
-            <div class="input-group">
-                <input type="text"
-                       class="form-control"
-                       name="searchTerm"
-                       value="@Model.SearchTerm"
-                       placeholder="Search by user, destination, purchase order, or description..."
-                       aria-label="Search invoices" />
-                <button class="btn btn-secondary" type="submit">
-                    <i class="fa fa-search"></i> Search
-                </button>
-                @if (!string.IsNullOrEmpty(Model.SearchTerm))
-                {
-                    <a asp-action="List" asp-route-storeId="@storeId" asp-route-all="@Model.All" class="btn btn-secondary">
-                        <i class="fa fa-times"></i> Clear
-                    </a>
-                }
-            </div>
-        </form>
-    </div>
+	<div class="col-auto d-flex align-items-center gap-2">
+		<span class="text-secondary small">Filter:</span>
+		<div class="dropdown">
+			<button class="btn btn-secondary btn-sm dropdown-toggle @(!string.IsNullOrEmpty(Model.StatusFilter) || !string.IsNullOrEmpty(Model.LabelFilter) ? "active" : "")"
+					type="button" data-bs-toggle="dropdown" id="combinedFilterBtn">
+				@{
+					var statusLabels = new Dictionary<string, string>
+					{
+						{ "AwaitingApproval", "Awaiting Approval" },
+						{ "AwaitingPayment", "Awaiting Payment" },
+						{ "InProgress", "In Progress" },
+						{ "Completed", "Completed" }
+					};
+
+					var parts = new List<string>();
+					if (!string.IsNullOrEmpty(Model.LabelFilter))
+						parts.Add(Model.LabelFilter);
+
+					if (!string.IsNullOrEmpty(Model.StatusFilter) && statusLabels.TryGetValue(Model.StatusFilter, out var friendlyName))
+						parts.Add(friendlyName);
+
+					@(parts.Any() ? string.Join(" · ", parts) : "None")
+				}
+			</button>
+			<ul class="dropdown-menu">
+				<li>
+					<a class="dropdown-item @(string.IsNullOrEmpty(Model.StatusFilter) && string.IsNullOrEmpty(Model.LabelFilter) ? "active" : "")"
+						   href="@Url.Action("List", new { storeId, all = Model.All, searchTerm = Model.SearchTerm })">
+						None
+					</a>
+				</li>
+
+				@if (Model.AllLabels.Any())
+				{
+					<li><hr class="dropdown-divider" /></li>
+					<li><span class="dropdown-header">By Label</span></li>
+					@foreach (var (label, _, count) in Model.AllLabels)
+					{
+						<li>
+							<a class="dropdown-item d-flex justify-content-between align-items-center @(Model.LabelFilter == label ? "active" : "")"
+								   href="@Url.Action("List", new { storeId, all = Model.All, searchTerm = Model.SearchTerm, labelFilter = label, statusFilter = Model.StatusFilter })">
+								<span>@label</span>
+								<span class="badge bg-secondary ms-2">@count</span>
+							</a>
+						</li>
+					}
+				}
+
+				<li><hr class="dropdown-divider" /></li>
+				<li><span class="dropdown-header">By Status</span></li>
+				@foreach (var status in new Dictionary<string, string>
+				{
+					{ "AwaitingApproval", "Awaiting Approval" },
+					{ "AwaitingPayment", "Awaiting Payment" },
+					{ "InProgress", "In Progress" },
+					{ "Completed", "Completed" }
+				})
+				{
+					<li>
+						<a class="dropdown-item @(Model.StatusFilter == status.Key ? "active" : "")"
+							   href="@Url.Action("List", new { storeId, all = Model.All, searchTerm = Model.SearchTerm, statusFilter = status.Key, labelFilter = Model.LabelFilter })">
+							@status.Value
+						</a>
+					</li>
+				}
+
+			</ul>
+		</div>
+	</div>
+
+	<div class="col-lg-6 ms-auto">
+		<form method="get" asp-action="List" asp-route-storeId="@storeId" asp-route-all="@Model.All">
+			<input type="hidden" name="statusFilter" value="@Model.StatusFilter" />
+			<input type="hidden" name="labelFilter" value="@Model.LabelFilter" />
+			<div class="input-group">
+				<input type="text"
+					   class="form-control"
+					   name="searchTerm"
+					   value="@Model.SearchTerm"
+					   placeholder="Search by user, destination, purchase order, or description..."
+					   aria-label="Search invoices" />
+				<button class="btn btn-secondary" type="submit">
+					<i class="fa fa-search"></i> Search
+				</button>
+				@if (!string.IsNullOrEmpty(Model.SearchTerm))
+				{
+					<a asp-action="List" asp-route-storeId="@storeId" asp-route-all="@Model.All"
+						   asp-route-statusFilter="@Model.StatusFilter" asp-route-labelFilter="@Model.LabelFilter" class="btn btn-secondary">
+						<i class="fa fa-times"></i> Clear
+					</a>
+				}
+			</div>
+		</form>
+	</div>
 </div>
 
 <nav id="SectionNav" class="mb-3">

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Views/VendorPayInvoice/List.cshtml
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Views/VendorPayInvoice/List.cshtml
@@ -63,7 +63,8 @@
 						{ "AwaitingApproval", "Awaiting Approval" },
 						{ "AwaitingPayment", "Awaiting Payment" },
 						{ "InProgress", "In Progress" },
-						{ "Completed", "Completed" }
+						{ "Completed", "Completed" },
+						{ "Cancelled", "Cancelled" }
 					};
 
 					var parts = new List<string>();
@@ -102,13 +103,7 @@
 
 				<li><hr class="dropdown-divider" /></li>
 				<li><span class="dropdown-header">By Status</span></li>
-				@foreach (var status in new Dictionary<string, string>
-				{
-					{ "AwaitingApproval", "Awaiting Approval" },
-					{ "AwaitingPayment", "Awaiting Payment" },
-					{ "InProgress", "In Progress" },
-					{ "Completed", "Completed" }
-				})
+				@foreach (var status in statusLabels)
 				{
 					<li>
 						<a class="dropdown-item @(Model.StatusFilter == status.Key ? "active" : "")"
@@ -348,15 +343,13 @@
                             }
                         });
                     });
-                });
 
-                const ppProgresses = document.getElementsByClassName("ppProgress");
-                for (var i = 0; i < ppProgresses.length; i++) {
-                    var pp = ppProgresses[i];
-                    var ppId = pp.getAttribute("data-pp");
-                    var template = document.getElementById("tooptip_template_" + ppId);
-                    pp.setAttribute("title", template.innerHTML);
-                }
+					const activeLabelFilter = "@Model.LabelFilter";
+					if (activeLabelFilter) {
+						applyLabelFilter(activeLabelFilter);
+					}
+					toggleButtons();
+                });
 
                 function allSelectedInState(state) {
                     var allCheckedItems = document.querySelectorAll('input[type="checkbox"].mass-action-select:checked');
@@ -365,15 +358,6 @@
                         var row = checkbox.closest('tr');
                         var stateCell = row.querySelector('td:nth-child(7)');
                         return stateCell.textContent.trim() === state;
-                    });
-                }
-
-                function selectedItemInState(states) {
-                    var allCheckedItems = document.querySelectorAll('input[type="checkbox"]:checked');
-                    return Array.from(allCheckedItems).every(function (checkbox) {
-                        var row = checkbox.closest('tr');
-                        var stateCell = row.querySelector('td:nth-child(7)');
-                        return states.includes(stateCell.textContent.trim());
                     });
                 }
 
@@ -410,11 +394,7 @@
                         }
                     });
 
-                    const btn = document.getElementById('labelFilterBtn');
-                    if (!label) {
-                        if (btn) btn.textContent = 'All';
-                        return;
-                    }
+					if (!label) return;
 
                     const userIds = new Set(labelUserIds[label] || []);
                     allRows.forEach(row => {
@@ -426,26 +406,11 @@
                             }
                         }
                     });
-
-                    if (btn) btn.textContent = label;
                 }
-
-                document.querySelectorAll('.label-filter-item').forEach(item => {
-                    item.addEventListener('click', e => {
-                        e.preventDefault();
-                        applyLabelFilter(item.dataset.label);
-                    });
-                });
-
-                document.getElementById('clearLabelFilter')?.addEventListener('click', e => {
-                    e.preventDefault();
-                    applyLabelFilter(null);
-                });
 
                 document.addEventListener('change', function () {
                     toggleButtons()
                 });
-                toggleButtons();
             </script>
         }
 

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Views/VendorPayInvoice/List.cshtml
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Views/VendorPayInvoice/List.cshtml
@@ -76,7 +76,7 @@
 			<ul class="dropdown-menu">
 				<li>
 					<a class="dropdown-item @(string.IsNullOrEmpty(Model.StatusFilter) && string.IsNullOrEmpty(Model.LabelFilter) ? "active" : "")"
-						   href="@Url.Action("List", new { storeId, all = Model.All, searchTerm = Model.SearchTerm })">
+						   href="@Url.Action("List", new { storeId, all = Model.All ? "true" : "false", searchTerm = Model.SearchTerm })">
 						None
 					</a>
 				</li>
@@ -89,7 +89,7 @@
 					{
 						<li>
 							<a class="dropdown-item d-flex justify-content-between align-items-center @(Model.LabelFilter == label ? "active" : "")"
-								   href="@Url.Action("List", new { storeId, all = Model.All, searchTerm = Model.SearchTerm, labelFilter = label, statusFilter = Model.StatusFilter })">
+								   href="@Url.Action("List", new { storeId, all = Model.All ? "true" : "false", searchTerm = Model.SearchTerm, labelFilter = label, statusFilter = Model.StatusFilter })">
 								<span>@label</span>
 								<span class="badge bg-secondary ms-2">@count</span>
 							</a>
@@ -104,7 +104,7 @@
 					var statusKey = status.ToString();
 					<li>
 						<a class="dropdown-item @(string.Equals(Model.StatusFilter, statusKey, StringComparison.OrdinalIgnoreCase) ? "active" : "")"
-							   href="@Url.Action("List", new { storeId, all = Model.All, searchTerm = Model.SearchTerm, statusFilter = statusKey, labelFilter = Model.LabelFilter })">
+							   href="@Url.Action("List", new { storeId, all = Model.All ? "true" : "false", searchTerm = Model.SearchTerm, statusFilter = statusKey, labelFilter = Model.LabelFilter })">
 							@status.GetDisplayName()
 						</a>
 					</li>
@@ -115,7 +115,7 @@
 	</div>
 
 	<div class="col-lg-6 ms-auto">
-		<form method="get" asp-action="List" asp-route-storeId="@storeId" asp-route-all="@Model.All">
+		<form method="get" asp-action="List" asp-route-storeId="@storeId" asp-route-all="@(Model.All ? "true" : "false")">
 			<input type="hidden" name="statusFilter" value="@Model.StatusFilter" />
 			<input type="hidden" name="labelFilter" value="@Model.LabelFilter" />
 			<div class="input-group">
@@ -130,7 +130,7 @@
 				</button>
 				@if (!string.IsNullOrEmpty(Model.SearchTerm))
 				{
-					<a asp-action="List" asp-route-storeId="@storeId" asp-route-all="@Model.All"
+					<a asp-action="List" asp-route-storeId="@storeId" asp-route-all="@(Model.All ? "true" : "false")"
 						   asp-route-statusFilter="@Model.StatusFilter" asp-route-labelFilter="@Model.LabelFilter" class="btn btn-secondary">
 						<i class="fa fa-times"></i> Clear
 					</a>

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Views/VendorPayInvoice/List.cshtml
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Views/VendorPayInvoice/List.cshtml
@@ -6,6 +6,7 @@
 @using BTCPayServer.Abstractions.Models
 @using BTCPayServer.Client
 @using BTCPayServer.RockstarDev.Plugins.VendorPay.Data.Models
+@using BTCPayServer.RockstarDev.Plugins.VendorPay.Services.Helpers
 @using BTCPayServer.RockstarDev.Plugins.VendorPay.Views
 @using Microsoft.AspNetCore.Http
 @model VendorPayInvoiceListViewModel
@@ -58,21 +59,16 @@
 			<button class="btn btn-secondary btn-sm dropdown-toggle @(!string.IsNullOrEmpty(Model.StatusFilter) || !string.IsNullOrEmpty(Model.LabelFilter) ? "active" : "")"
 					type="button" data-bs-toggle="dropdown" id="combinedFilterBtn">
 				@{
-					var statusLabels = new Dictionary<string, string>
-					{
-						{ "AwaitingApproval", "Awaiting Approval" },
-						{ "AwaitingPayment", "Awaiting Payment" },
-						{ "InProgress", "In Progress" },
-						{ "Completed", "Completed" },
-						{ "Cancelled", "Cancelled" }
-					};
+					var allStatuses = Enum.GetValues<VendorPayInvoiceState>();
 
 					var parts = new List<string>();
 					if (!string.IsNullOrEmpty(Model.LabelFilter))
 						parts.Add(Model.LabelFilter);
 
-					if (!string.IsNullOrEmpty(Model.StatusFilter) && statusLabels.TryGetValue(Model.StatusFilter, out var friendlyName))
-						parts.Add(friendlyName);
+					if (!string.IsNullOrEmpty(Model.StatusFilter)
+						&& Enum.TryParse<VendorPayInvoiceState>(Model.StatusFilter, ignoreCase: true, out var activeStatus)
+						&& Enum.IsDefined(typeof(VendorPayInvoiceState), activeStatus))
+						parts.Add(activeStatus.GetDisplayName());
 
 					@(parts.Any() ? string.Join(" · ", parts) : "None")
 				}
@@ -103,12 +99,13 @@
 
 				<li><hr class="dropdown-divider" /></li>
 				<li><span class="dropdown-header">By Status</span></li>
-				@foreach (var status in statusLabels)
+				@foreach (var status in allStatuses)
 				{
+					var statusKey = status.ToString();
 					<li>
-						<a class="dropdown-item @(Model.StatusFilter == status.Key ? "active" : "")"
-							   href="@Url.Action("List", new { storeId, all = Model.All, searchTerm = Model.SearchTerm, statusFilter = status.Key, labelFilter = Model.LabelFilter })">
-							@status.Value
+						<a class="dropdown-item @(string.Equals(Model.StatusFilter, statusKey, StringComparison.OrdinalIgnoreCase) ? "active" : "")"
+							   href="@Url.Action("List", new { storeId, all = Model.All, searchTerm = Model.SearchTerm, statusFilter = statusKey, labelFilter = Model.LabelFilter })">
+							@status.GetDisplayName()
 						</a>
 					</li>
 				}

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Views/VendorPayInvoice/List.cshtml
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Views/VendorPayInvoice/List.cshtml
@@ -149,6 +149,8 @@
            asp-action="List"
            asp-route-storeId="@storeId"
            asp-route-searchTerm="@Model.SearchTerm"
+           asp-route-statusFilter="@Model.StatusFilter"
+           asp-route-labelFilter="@Model.LabelFilter"
            class="nav-link @(!Model.All ? "active" : "")"
            role="tab">Active</a>
 
@@ -157,6 +159,8 @@
            asp-route-storeId="@storeId"
            asp-route-all="true"
            asp-route-searchTerm="@Model.SearchTerm"
+           asp-route-statusFilter="@Model.StatusFilter"
+           asp-route-labelFilter="@Model.LabelFilter"
            class="nav-link @(Model.All ? "active" : "")"
            role="tab">All</a>
     </div>

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.RockstarStrikeUtils/BTCPayServer.RockstarDev.Plugins.RockstarStrikeUtils.csproj
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.RockstarStrikeUtils/BTCPayServer.RockstarDev.Plugins.RockstarStrikeUtils.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>12</LangVersion>
     </PropertyGroup>
     <!-- -->
@@ -43,11 +43,11 @@
      -->
 
     <ItemGroup Condition="'$(Configuration)' != 'Release'">
-        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.10.0"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11"/>
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.3.0"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.4"/>
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1"/>
     </ItemGroup>
 
     <!-- Strike reference -->

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.RockstarStrikeUtils/Data/Migrations/20260506141459_Net10ModelSync.Designer.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.RockstarStrikeUtils/Data/Migrations/20260506141459_Net10ModelSync.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BTCPayServer.RockstarDev.Plugins.RockstarStrikeUtils.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BTCPayServer.RockstarDev.Plugins.RockstarStrikeUtils.Data.Migrations
 {
     [DbContext(typeof(RockstarStrikeDbContext))]
-    partial class RockstarStrikeDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260506141459_Net10ModelSync")]
+    partial class Net10ModelSync
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.RockstarStrikeUtils/Data/Migrations/20260506141459_Net10ModelSync.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.RockstarStrikeUtils/Data/Migrations/20260506141459_Net10ModelSync.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BTCPayServer.RockstarDev.Plugins.RockstarStrikeUtils.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class Net10ModelSync : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "CreatedBy",
+                schema: "BTCPayServer.RockstarDev.Plugins.RockstarStrikeUtils",
+                table: "ExchangeOrders",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "CreatedForDate",
+                schema: "BTCPayServer.RockstarDev.Plugins.RockstarStrikeUtils",
+                table: "ExchangeOrders",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreatedForDate",
+                schema: "BTCPayServer.RockstarDev.Plugins.RockstarStrikeUtils",
+                table: "ExchangeOrders");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "CreatedBy",
+                schema: "BTCPayServer.RockstarDev.Plugins.RockstarStrikeUtils",
+                table: "ExchangeOrders",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(50)",
+                oldMaxLength: 50,
+                oldNullable: true);
+        }
+    }
+}

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Stripe/BTCPayServer.RockstarDev.Plugins.Stripe.csproj
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Stripe/BTCPayServer.RockstarDev.Plugins.Stripe.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>12</LangVersion>
     </PropertyGroup>
     <!-- -->
@@ -43,11 +43,11 @@
      -->
 
     <ItemGroup Condition="'$(Configuration)' != 'Release'">
-        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.10.0"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11"/>
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.3.0"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.4"/>
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.TransactionCounter/BTCPayServer.RockstarDev.Plugins.TransactionCounter.csproj
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.TransactionCounter/BTCPayServer.RockstarDev.Plugins.TransactionCounter.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>12</LangVersion>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Vouchers/BTCPayServer.RockstarDev.Plugins.Vouchers.csproj
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Vouchers/BTCPayServer.RockstarDev.Plugins.Vouchers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>12</LangVersion>
     </PropertyGroup>
     <!-- -->

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.WalletHistoryReload/BTCPayServer.RockstarDev.Plugins.WalletHistoryReload.csproj
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.WalletHistoryReload/BTCPayServer.RockstarDev.Plugins.WalletHistoryReload.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>12</LangVersion>
     </PropertyGroup>
     <!-- -->
@@ -32,7 +32,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Npgsql" Version="8.0.6"/>
+        <PackageReference Include="Npgsql" Version="10.0.2"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.WalletSweeper/BTCPayServer.RockstarDev.Plugins.WalletSweeper.csproj
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.WalletSweeper/BTCPayServer.RockstarDev.Plugins.WalletSweeper.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>12</LangVersion>
   </PropertyGroup>
   <!-- -->
@@ -41,11 +41,11 @@
 
 
   <ItemGroup Condition="'$(Configuration)' != 'Release'">
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.10.0"/>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0"/>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0"/>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11"/>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.3.0"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.4"/>
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1"/>
   </ItemGroup>
 
 

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.XpubExtractor/BTCPayServer.RockstarDev.Plugins.XpubExtractor.csproj
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.XpubExtractor/BTCPayServer.RockstarDev.Plugins.XpubExtractor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>12</LangVersion>
     </PropertyGroup>
     <!-- -->


### PR DESCRIPTION
Based on feedback from BTrust team

Yes category work..  if they try to repay another set of invoices, and filter by a particular category, both paid and unpaid invoices appear


So to the current category filter, I added a filter by status


<img width="1427" height="560" alt="image" src="https://github.com/user-attachments/assets/da8179ca-0973-43bd-9fb0-7c39813d607e" />


<img width="1673" height="491" alt="image" src="https://github.com/user-attachments/assets/9817a240-92e4-4310-883a-382cd33bbf87" />
