### PR TITLE
resolve bug for label filter

### DIFF
--- a/BTCPayServer.Plugins.Tests/VendorPayTests/VendorPayLabelCountsTests.cs
+++ b/BTCPayServer.Plugins.Tests/VendorPayTests/VendorPayLabelCountsTests.cs
@@ -1,0 +1,89 @@
+using System.Linq;
+using BTCPayServer.RockstarDev.Plugins.VendorPay.Data.Models;
+using BTCPayServer.RockstarDev.Plugins.VendorPay.Services.Helpers;
+using Xunit;
+
+namespace BTCPayServer.Plugins.Tests.VendorPayTests;
+
+public class VendorPayLabelCountsTests
+{
+    private record InvoiceFixture(string UserId, VendorPayInvoiceState State);
+
+    [Fact]
+    public void CountInvoicesByUser_CountsAllStates()
+    {
+        var invoices = new[]
+        {
+            new InvoiceFixture("u1", VendorPayInvoiceState.Completed),
+            new InvoiceFixture("u1", VendorPayInvoiceState.Completed),
+            new InvoiceFixture("u1", VendorPayInvoiceState.AwaitingApproval),
+            new InvoiceFixture("u2", VendorPayInvoiceState.Completed),
+            new InvoiceFixture("u3", VendorPayInvoiceState.AwaitingApproval),
+            new InvoiceFixture("u4", VendorPayInvoiceState.Cancelled),
+        };
+
+        var counts = VendorPayLabelCounts.CountInvoicesByUser(invoices, i => i.UserId);
+
+        Assert.Equal(3, counts["u1"]);
+        Assert.Equal(1, counts["u2"]);
+        Assert.Equal(1, counts["u3"]);
+        Assert.Equal(1, counts["u4"]);
+    }
+
+    [Fact]
+    public void LabelCount_AppearsForUsersWithoutAwaitingApproval_RegressionForPr132()
+    {
+        // PR #132 bug: labels were hidden in the vendor invoice filter dropdown
+        // when none of the tagged users had AwaitingApproval invoices, because
+        // the per-label Count was sourced only from awaitingByUser. After the
+        // fix, count reflects total invoices regardless of state, so the label
+        // appears as long as any invoice exists for any tagged user.
+        var invoices = new[]
+        {
+            new InvoiceFixture("u1", VendorPayInvoiceState.Completed),
+            new InvoiceFixture("u2", VendorPayInvoiceState.InProgress),
+        };
+        var labelUserIds = new[] { "u1", "u2" };
+
+        var counts = VendorPayLabelCounts.CountInvoicesByUser(invoices, i => i.UserId);
+        var labelCount = VendorPayLabelCounts.LabelCount(labelUserIds, counts);
+
+        Assert.Equal(2, labelCount);
+        Assert.True(labelCount > 0,
+            "Label should appear in filter when tagged users have any invoices in any state");
+    }
+
+    [Fact]
+    public void LabelCount_ZeroWhenNoInvoicesExistForTaggedUsers()
+    {
+        // Inverse case: a label whose tagged users have NO invoices at all
+        // should still produce Count=0 and be filtered out by the controller's
+        // .Where(l => l.Count > 0) guard. Confirms the fix doesn't accidentally
+        // surface empty labels.
+        var invoices = new[]
+        {
+            new InvoiceFixture("other-user", VendorPayInvoiceState.Completed),
+        };
+        var labelUserIds = new[] { "u1", "u2" };
+
+        var counts = VendorPayLabelCounts.CountInvoicesByUser(invoices, i => i.UserId);
+        var labelCount = VendorPayLabelCounts.LabelCount(labelUserIds, counts);
+
+        Assert.Equal(0, labelCount);
+    }
+
+    [Fact]
+    public void LabelCount_SkipsUnknownUserIdsWithoutThrowing()
+    {
+        var invoices = new[]
+        {
+            new InvoiceFixture("u1", VendorPayInvoiceState.Completed),
+        };
+        var labelUserIds = new[] { "u1", "u-unknown" };
+
+        var counts = VendorPayLabelCounts.CountInvoicesByUser(invoices, i => i.UserId);
+        var labelCount = VendorPayLabelCounts.LabelCount(labelUserIds, counts);
+
+        Assert.Equal(1, labelCount);
+    }
+}

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/BTCPayServer.RockstarDev.Plugins.Payroll.csproj
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/BTCPayServer.RockstarDev.Plugins.Payroll.csproj
@@ -12,7 +12,7 @@
     <Description>
       Accept invoices from various sources and easily pay them out from Bitcoin wallet. Pay all your vendors using Bitcoin.
     </Description>
-    <Version>0.8.2</Version>
+    <Version>0.8.3</Version>
   </PropertyGroup>
   <!-- Plugin development properties -->
   <PropertyGroup>

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Controllers/VendorPayInvoiceController.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Controllers/VendorPayInvoiceController.cs
@@ -97,15 +97,12 @@ public class VendorPayInvoiceController(
                 g => g.Key,
                 g => g.Select(x => x.UserId).Distinct().ToArray(), StringComparer.OrdinalIgnoreCase);
 
-        var awaitingByUser = payrollInvoices.Where(i => i.State == VendorPayInvoiceState.AwaitingApproval)
-            .GroupBy(i => i.UserId).ToDictionary(g => g.Key, g => g.Count());
-
         var allLabels = labelToUserIds.Select(kv => (
                 Label: kv.Key,
                 Color: userLabels.Where(u => kv.Value.Contains(u.Key))
                     .SelectMany(u => u.Value)
                     .FirstOrDefault(l => l.Label.Equals(kv.Key, StringComparison.OrdinalIgnoreCase)).Color,
-                Count: kv.Value.Sum(uid => awaitingByUser.TryGetValue(uid, out var c) ? c : 0)
+                Count: kv.Value.Sum(uid => payrollInvoices.Count(i => i.UserId == uid))
             ))
             .Where(l => l.Count > 0).OrderBy(l => l.Label).ToArray();
 

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Controllers/VendorPayInvoiceController.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Controllers/VendorPayInvoiceController.cs
@@ -97,12 +97,14 @@ public class VendorPayInvoiceController(
                 g => g.Key,
                 g => g.Select(x => x.UserId).Distinct().ToArray(), StringComparer.OrdinalIgnoreCase);
 
+        var invoiceCountByUser = VendorPayLabelCounts.CountInvoicesByUser(payrollInvoices, i => i.UserId);
+
         var allLabels = labelToUserIds.Select(kv => (
                 Label: kv.Key,
                 Color: userLabels.Where(u => kv.Value.Contains(u.Key))
                     .SelectMany(u => u.Value)
                     .FirstOrDefault(l => l.Label.Equals(kv.Key, StringComparison.OrdinalIgnoreCase)).Color,
-                Count: kv.Value.Sum(uid => payrollInvoices.Count(i => i.UserId == uid))
+                Count: VendorPayLabelCounts.LabelCount(kv.Value, invoiceCountByUser)
             ))
             .Where(l => l.Count > 0).OrderBy(l => l.Label).ToArray();
 

--- a/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Services/Helpers/VendorPayLabelCounts.cs
+++ b/Plugins/BTCPayServer.RockstarDev.Plugins.Payroll/Services/Helpers/VendorPayLabelCounts.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BTCPayServer.RockstarDev.Plugins.VendorPay.Services.Helpers;
+
+public static class VendorPayLabelCounts
+{
+    // Counts must include invoices in every state, not only AwaitingApproval -
+    // see the regression test for PR #132 (label-filter dropdown hid labels when
+    // tagged users had no invoices in that single state).
+    public static IReadOnlyDictionary<string, int> CountInvoicesByUser<T>(
+        IEnumerable<T> invoices,
+        Func<T, string> userIdSelector)
+    {
+        return invoices
+            .GroupBy(userIdSelector)
+            .ToDictionary(g => g.Key, g => g.Count());
+    }
+
+    public static int LabelCount(
+        IEnumerable<string> userIdsForLabel,
+        IReadOnlyDictionary<string, int> invoiceCountByUser)
+    {
+        return userIdsForLabel.Sum(uid => invoiceCountByUser.TryGetValue(uid, out var c) ? c : 0);
+    }
+}


### PR DESCRIPTION
Labels in the vendor invoice filter dropdown were only showing when users had AwaitingApproval invoices. This fix is done so labels always appear in the filter as long as any invoice exists for that label's users.

<img width="1235" height="475" alt="image" src="https://github.com/user-attachments/assets/547ce0fc-5d79-483a-90b6-54a430a8aaac" />
