### PR TITLE
ci: run Cleanup Docker unconditionally

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -85,4 +85,5 @@ jobs:
                 run: cd BTCPayServer.Plugins.Tests && dotnet run -- -trait "Category=PlaywrightUITest" -class "BTCPayServer.Plugins.Tests.VendorPayPluginUITest"
 
             -   name: Cleanup Docker
+                if: ${{ always() }}
                 run: docker compose -f submodules/btcpayserver/BTCPayServer.Tests/docker-compose.yml down --volumes


### PR DESCRIPTION
Addresses CodeRabbit review comment [3628456606](https://github.com/rockstardev/BTCPayServerPlugins.RockstarDev/pull/135#discussion_r3628456606) on PR #135. Adds `if: ${{ always() }}` to the Cleanup Docker step so containers + volumes still get removed when Run tests fails or times out.

Hit this during PR #135 bisection - after test-step timeouts, containers were left running (`btcpayservertests-*`) until GitHub Actions cleanup killed the runner. On the shared runner they get reaped either way, but on self-hosted this would leak resources indefinitely.